### PR TITLE
Rename mc::range to mc::block, better bucket scaling

### DIFF
--- a/src/gribjump/GribJumpDataAccessor.h
+++ b/src/gribjump/GribJumpDataAccessor.h
@@ -19,13 +19,13 @@ namespace gribjump {
 class GribJumpDataAccessor : public mc::DataAccessor {
 
 public:
-    GribJumpDataAccessor(eckit::DataHandle& dh, const mc::Range range) : dh_{dh}, data_section_range_{range} {}
+    GribJumpDataAccessor(eckit::DataHandle& dh, const mc::Block range) : dh_{dh}, data_section_range_{range} {}
 
     void write(const eckit::Buffer& buffer, const size_t offset) const override {
         NOTIMP;
     }
 
-    eckit::Buffer read(const mc::Range& range) const override {
+    eckit::Buffer read(const mc::Block& range) const override {
         eckit::Offset offset = range.first;
         eckit::Length size = range.second;
         
@@ -51,7 +51,7 @@ public:
 
 private:
     eckit::DataHandle& dh_;
-    mc::Range data_section_range_;
+    mc::Block data_section_range_;
 };
 
 } // namespace gribjump

--- a/src/gribjump/compression/DataAccessor.h
+++ b/src/gribjump/compression/DataAccessor.h
@@ -26,7 +26,7 @@ class DataAccessor {
 public:
     virtual ~DataAccessor() = default;
     virtual void write(const eckit::Buffer& buffer, const size_t offset) const = 0;
-    virtual eckit::Buffer read(const Range& range) const = 0;
+    virtual eckit::Buffer read(const Block& range) const = 0;
     virtual eckit::Buffer read() const = 0;
     virtual size_t eof() const = 0;
 };
@@ -43,7 +43,7 @@ public:
         NOTIMP;
     }
 
-    eckit::Buffer read(const Range& range) const override {
+    eckit::Buffer read(const Block& range) const override {
         const auto [offset, size] = range;
         eckit::Buffer buf(size);
         ifs_.seekg(offset, std::ios::beg);
@@ -89,7 +89,7 @@ public:
         NOTIMP;
     }
 
-    eckit::Buffer read(const Range& range) const override {
+    eckit::Buffer read(const Block& range) const override {
         const auto [offset, size] = range;
         if (offset + size > buf_.size()) {
             std::stringstream ss;

--- a/src/gribjump/compression/NumericCompressor.h
+++ b/src/gribjump/compression/NumericCompressor.h
@@ -37,23 +37,23 @@ public:
   using CompressedData = eckit::Buffer;
   using Values = std::vector<ValueType>;
   virtual Values decode(const CompressedData&) = 0;
-  virtual Values decode(const std::shared_ptr<DataAccessor>, const Range&) = 0;
+  virtual Values decode(const std::shared_ptr<DataAccessor>, const Block&) = 0;
 
 
-  virtual std::vector<Values> decode(const std::shared_ptr<DataAccessor>& accessor, const std::vector<mc::Range>& ranges) {
+  virtual std::vector<Values> decode(const std::shared_ptr<DataAccessor>& accessor, const std::vector<mc::Block>& ranges) {
     using Values = typename NumericDecompressor<ValueType>::Values;
     std::vector<Values> result;
     decode(accessor, ranges, result);
     return result;
   }
 
-  virtual void decode(const std::shared_ptr<DataAccessor>& accessor, const std::vector<mc::Range>& ranges, std::vector<Values>& result) {
+  virtual void decode(const std::shared_ptr<DataAccessor>& accessor, const std::vector<mc::Block>& ranges, std::vector<Values>& result) {
     using Values = typename NumericDecompressor<ValueType>::Values;
     
-    std::unordered_map<Range, std::pair<Range, std::shared_ptr<Values>>> ranges_map;
+    std::unordered_map<Block, std::pair<Block, std::shared_ptr<Values>>> ranges_map;
 
     // find which sub_ranges are in which buckets
-    RangeBuckets buckets;
+    BlockBuckets buckets;
     for (const auto& range : ranges) {
       buckets << range;
     }

--- a/src/gribjump/compression/Range.h
+++ b/src/gribjump/compression/Range.h
@@ -17,31 +17,29 @@
 #include <iostream>
 #include <tuple>
 #include <cstdint>
-
 namespace mc {
-using Range = std::pair<size_t, size_t>;
+using Block = std::pair<size_t, size_t>;
 }
 
 template<>
-struct std::hash<mc::Range> {
-    std::size_t operator()(const mc::Range& range) const;
+struct std::hash<mc::Block> {
+    std::size_t operator()(const mc::Block& range) const;
 };
 
 
 namespace mc {
 
 // A bucket is a continous range of data that can be decoded in one go
-std::pair<size_t, size_t> get_begin_end(const Range& range);
-using SubRange = Range;
-using SubRanges = std::vector<SubRange>;
-using RangeBucket = std::pair<Range, SubRanges>;
-using RangeBuckets = std::list<RangeBucket>;
-
+std::pair<size_t, size_t> get_begin_end(const Block& range);
+using SubBlock = Block;
+using SubBlocks = std::vector<SubBlock>;
+using BlockBucket = std::pair<Block, SubBlocks>;
+using BlockBuckets = std::vector<BlockBucket>; // Sorted to allow binary search (std::lower_bound)
 } // namespace mc
 
-std::ostream& operator<<(std::ostream& os, const mc::Range& range);
-std::ostream& operator<<(std::ostream& os, const mc::RangeBucket& bucket);
-mc::RangeBuckets& operator<<(mc::RangeBuckets& buckets, const mc::Range& r);
-mc::Range operator+(const mc::Range& r1, const mc::Range& r2);
+std::ostream& operator<<(std::ostream& os, const mc::Block& range);
+std::ostream& operator<<(std::ostream& os, const mc::BlockBucket& bucket);
+mc::BlockBuckets& operator<<(mc::BlockBuckets& buckets, const mc::Block& r);
+mc::Block operator+(const mc::Block& r1, const mc::Block& r2);
 
-std::pair<size_t, size_t> begin_end(const mc::Range& range);
+std::pair<size_t, size_t> begin_end(const mc::Block& range);

--- a/src/gribjump/compression/compressors/Aec.h
+++ b/src/gribjump/compression/compressors/Aec.h
@@ -193,7 +193,7 @@ public:
   }
 
 
-  Values decode(const std::shared_ptr<DataAccessor> accessor, const Range& range) override
+  Values decode(const std::shared_ptr<DataAccessor> accessor, const Block& range) override
   {
     if (sizeof(ValueType) == 1 && !(bits_per_sample_ > 0 && bits_per_sample_ <= 8))
       throw eckit::Exception("bits_per_sample must be between 1 and 8 for 1-byte types", Here());

--- a/src/gribjump/compression/compressors/Ccsds.h
+++ b/src/gribjump/compression/compressors/Ccsds.h
@@ -204,7 +204,7 @@ public:
   }
 
 
-  Values decode(const std::shared_ptr<DataAccessor> accessor, const Range& range) override {
+  Values decode(const std::shared_ptr<DataAccessor> accessor, const Block& range) override {
     if (range.second == 0)
       return Values{};
 
@@ -245,7 +245,7 @@ private:
   size_t n_elems_;
 
   template <typename SimpleValueType>
-  Values decode_range_ (const std::shared_ptr<DataAccessor> accessor, const Range& simple_range, double bscale, double dscale) {
+  Values decode_range_ (const std::shared_ptr<DataAccessor> accessor, const Block& simple_range, double bscale, double dscale) {
     AecDecompressor<SimpleValueType> aec{};
     auto flags = modify_aec_flags(flags_);
     aec.flags(flags);

--- a/src/gribjump/compression/compressors/Simple.h
+++ b/src/gribjump/compression/compressors/Simple.h
@@ -103,7 +103,7 @@ public:
   size_t buffer_size() const { return buffer_size_; }
   SimpleDecompressor& buffer_size(size_t buffer_size) { buffer_size_ = buffer_size; return *this; }
 
-  Values decode(const std::shared_ptr<DataAccessor> accessor, const Range& range) override {
+  Values decode(const std::shared_ptr<DataAccessor> accessor, const Block& range) override {
     //SP sp{};
     using SP = SimplePacking<ValueType>;
     SimplePacking<double> sp{};
@@ -121,12 +121,12 @@ public:
     size_t end = offset + size;
     size_t new_end = (end + (chunk_nvals - 1)) / chunk_nvals * chunk_nvals;
     size_t new_size = new_end - new_offset;
-    Range inclusive_range{new_offset, new_size};
+    Block inclusive_range{new_offset, new_size};
 
     params.n_vals = new_size;
 
     size_t last_pos = std::min(bin_pos<ValueType>(new_size, bits_per_value_), accessor->eof() - bin_pos<ValueType>(new_offset, bits_per_value_));
-    Range data_range{bin_pos<ValueType>(new_offset, bits_per_value_), last_pos};
+    Block data_range{bin_pos<ValueType>(new_offset, bits_per_value_), last_pos};
     eckit::Buffer compressed = accessor->read(data_range);
 
     typename SP::Buffer data{(unsigned char*) compressed.data(), (unsigned char*) compressed.data() + data_range.second};

--- a/src/gribjump/jumper/CcsdsJumper.cc
+++ b/src/gribjump/jumper/CcsdsJumper.cc
@@ -44,7 +44,7 @@ void CcsdsJumper::readValues(eckit::DataHandle& dh, const eckit::Offset offset, 
         .offsets(info.ccsdsOffsets());
 
 
-    auto data_range = mc::Range{offset + info.offsetBeforeData(), info.offsetAfterData() - info.offsetBeforeData()};
+    auto data_range = mc::Block{offset + info.offsetBeforeData(), info.offsetAfterData() - info.offsetBeforeData()};
     std::shared_ptr<mc::DataAccessor> data_accessor = std::make_shared<GribJumpDataAccessor>(dh, data_range);
 
     // TODO(maee): Optimize this

--- a/src/gribjump/jumper/Jumper.cc
+++ b/src/gribjump/jumper/Jumper.cc
@@ -44,11 +44,11 @@ std::vector<std::bitset<64>> toBitset(const Bitmap& bitmap) {
 
 // Convert ranges to intervals
 // TODO(maee): Simplification: Switch to intervals or ranges
-std::vector<mc::Range> toRanges(const std::vector<Interval>& intervals) {
-    std::vector<mc::Range> ranges;
+std::vector<mc::Block> toRanges(const std::vector<Interval>& intervals) {
+    std::vector<mc::Block> ranges;
     std::transform(intervals.begin(), intervals.end(), std::back_inserter(ranges), [](auto interval) {
         auto [begin, end] = interval;
-        return mc::Range{begin, end - begin};
+        return mc::Block{begin, end - begin};
     });
     return ranges;
 }

--- a/src/gribjump/jumper/Jumper.h
+++ b/src/gribjump/jumper/Jumper.h
@@ -59,6 +59,6 @@ public:
 
 // Convert ranges to intervals
 // TODO(maee): Simplification: Switch to intervals or ranges
-std::vector<mc::Range> toRanges(const std::vector<Interval>& intervals);
+std::vector<mc::Block> toRanges(const std::vector<Interval>& intervals);
 
 } // namespace gribjump

--- a/src/gribjump/jumper/SimpleJumper.cc
+++ b/src/gribjump/jumper/SimpleJumper.cc
@@ -31,7 +31,7 @@ void SimpleJumper::readValues(eckit::DataHandle& dh, const eckit::Offset offset,
     const SimpleInfo& info = *psimple;
 
 
-    std::shared_ptr<mc::DataAccessor> data_accessor = std::make_shared<GribJumpDataAccessor>(dh, mc::Range{offset + info.offsetBeforeData(), info.offsetAfterData() - info.offsetBeforeData()}); // TODO XXX
+    std::shared_ptr<mc::DataAccessor> data_accessor = std::make_shared<GribJumpDataAccessor>(dh, mc::Block{offset + info.offsetBeforeData(), info.offsetAfterData() - info.offsetBeforeData()}); // TODO XXX
     mc::SimpleDecompressor<double> simple{};
     simple
         .bits_per_value(info.bitsPerValue())

--- a/src/gribjump/remote/RemoteGribJump.h
+++ b/src/gribjump/remote/RemoteGribJump.h
@@ -24,7 +24,7 @@ enum class RequestType : uint16_t {
     SCAN,
     FORWARD_EXTRACT
 };
-constexpr static uint16_t remoteProtocolVersion = 1;
+constexpr static uint16_t remoteProtocolVersion = 2;
 
 class RemoteGribJump : public GribJumpBase {
 

--- a/tests/test_misc_units.cc
+++ b/tests/test_misc_units.cc
@@ -13,6 +13,7 @@
 
 #include "eckit/testing/Test.h"
 #include "gribjump/info/LRUCache.h"
+#include "gribjump/compression/NumericCompressor.h"
 
 
 #include "metkit/mars/MarsParser.h"
@@ -56,7 +57,47 @@ CASE( "test_lru" ){
 
     EXPECT_THROWS_AS(cache.get("z"), eckit::BadValue);
 }
+
 //-----------------------------------------------------------------------------
+CASE( "test buckets" ){
+    using namespace mc;
+    BlockBuckets buckets;
+    for (size_t i = 100; i < 1000; i += 100) {
+        mc::Block r{i, 10};
+        buckets << r;
+    }
+
+    // i.e. {100, 10}, {200, 10}, ..., {900, 10}
+    EXPECT_EQUAL(buckets.size(), 9);
+
+    // Add a bucket that extends {100, 10} forward
+    buckets << Block{205, 20};
+
+    // Add a bucket that extends {100, 10} backward
+    buckets << Block{195, 10};
+
+    EXPECT_EQUAL(buckets.size(), 9); // We've only grown existing bucket
+    EXPECT_EQUAL(buckets[1].second.size(), 3); // The second bucket now has 3 subblocks
+
+    // Check that it has the correct extents. Should be from 195 to 225 i.e. {195, 30}
+    EXPECT_EQUAL(buckets[1].first.first, 195);
+    EXPECT_EQUAL(buckets[1].first.second, 30);
+
+    // Add a bucket that overlaps with nothing to the beginning, middle and end
+    buckets << Block{0, 10} << Block{150, 10} << Block{1500, 10};
+    EXPECT_EQUAL(buckets.size(), 12); // We've added 3 new buckets
+
+    // Add a bucket that merges two adjacent buckets
+    buckets << Block{305, 100};
+    std::cout << buckets << std::endl;
+    EXPECT_EQUAL(buckets.size(), 11); // We've merged two buckets
+
+    // Add a bucket that completely overlaps with all buckets
+    buckets << Block{0, 2000};
+    EXPECT_EQUAL(buckets.size(), 1); // We've merged all buckets
+    EXPECT_EQUAL(buckets[0].first.first, 0);
+    EXPECT_EQUAL(buckets[0].first.second, 2000);
+}
 
 }  // namespace test
 }  // namespace gribjump


### PR DESCRIPTION
Noticed that gribjump.extract scaled very poorly when using many ranges for the same field. This was due to a linearly scaling method used when inserting ranges into "buckets".  Rewrote this method to use binary search.

Also extended its functionality to support more elaborate merging of overlapping ranges, which were not previously supported, or at least not correctly. To be seen if this is useful (it would be convenient for polytope if we could support overlapping ranges)