### PR TITLE
Feature/short lived fdb

### DIFF
--- a/src/gribjump/Lister.cc
+++ b/src/gribjump/Lister.cc
@@ -12,7 +12,6 @@
 
 #include "eckit/config/Resource.h"
 #include "eckit/log/Log.h"
-#include "eckit/thread/AutoLock.h"
 
 #include "gribjump/Lister.h"
 #include "gribjump/GribJumpException.h"
@@ -43,8 +42,6 @@ FDBLister::~FDBLister() {
 }
 
 std::vector<eckit::URI> FDBLister::list(const std::vector<metkit::mars::MarsRequest> requests) {
-
-    eckit::AutoLock<FDBLister> lock(this);
 
     std::vector<eckit::URI> uris;
     fdb5::FDB fdb;
@@ -84,7 +81,6 @@ std::string fdbkeyToStr(const fdb5::Key& key) {
 
 // i.e. do all of the listing work I want...
 filemap_t FDBLister::fileMap(const metkit::mars::MarsRequest& unionRequest, const ExItemMap& reqToExtractionItem) {
-    eckit::AutoLock<FDBLister> lock(this);
     filemap_t filemap;
 
     fdb5::FDBToolRequest fdbreq(unionRequest);
@@ -171,7 +167,6 @@ std::map< eckit::PathName, eckit::OffsetList > FDBLister::filesOffsets(const std
 } 
 
 std::vector<eckit::URI> FDBLister::URIs(const std::vector<metkit::mars::MarsRequest>& requests) {
-    eckit::AutoLock<FDBLister> lock(this);
     std::vector<eckit::URI> uris;
     fdb5::FDB fdb;
     for (auto& request : requests) {
@@ -193,7 +188,6 @@ std::map<std::string, std::unordered_set<std::string> > FDBLister::axes(const st
 }
 
 std::map<std::string, std::unordered_set<std::string> > FDBLister::axes(const fdb5::FDBToolRequest& request, int level) {
-    eckit::AutoLock<FDBLister> lock(this);
     std::map<std::string, std::unordered_set<std::string>> values;
 
     LOG_DEBUG_LIB(LibGribJump) << "Using FDB's (new) axes impl" << std::endl;

--- a/src/gribjump/Lister.h
+++ b/src/gribjump/Lister.h
@@ -34,17 +34,11 @@ public:
     virtual std::vector<eckit::URI> list(const std::vector<metkit::mars::MarsRequest> requests) = 0; // <-- May not want to use mars request?
     virtual std::map<std::string, std::unordered_set<std::string> > axes(const std::string& request, int level) = 0 ;
 
-    void lock() { mutex_.lock(); locked_ = true; }
-    void unlock() { mutex_.unlock(); locked_ = false; }
-
 protected:
 
     Lister();
     ~Lister();
     
-private:
-    std::mutex mutex_;
-    bool locked_ = false;
 };
 
 //  ------------------------------------------------------------------

--- a/src/gribjump/Lister.h
+++ b/src/gribjump/Lister.h
@@ -70,7 +70,6 @@ private:
     ~FDBLister();
 
 private:
-    fdb5::FDB fdb_;
     bool allowMissing_;
 };
 

--- a/src/gribjump/remote/GribJumpUser.cc
+++ b/src/gribjump/remote/GribJumpUser.cc
@@ -44,10 +44,14 @@ void GribJumpUser::serve(eckit::Stream& s, std::istream& in, std::ostream& out) 
         try {
             s << e;
         }
-        catch (std::exception& a) {
-            eckit::Log::error() << "** " << a.what() << " Caught in " << Here() << std::endl;
+        catch (...) {
             eckit::Log::error() << "** Exception is ignored" << std::endl;
         }
+    }
+    catch (...) {
+        eckit::Log::error() << "** Unknown exception caught in " << Here() << std::endl;
+        eckit::Log::error() << "** Exception is ignored" << std::endl;
+        MetricsManager::instance().set("error", "Uncaught exception");
     }
         
     LOG_DEBUG_LIB(LibGribJump) << eckit::system::ResourceUsage() << std::endl;


### PR DESCRIPTION
Rather than one infinitely long lived fdb object in FDBLister, we instead always create a new one when we receieve a new request. We also no longer lock FDB axes behind a mutex.

This assumes that:

- FDB list and axes no longer has thread-safety issues.
- FDB no longer has destruction issues.

Do not merge until some stress testing has taken place with many parallel requests. Need to test local FDB (atos) and remote FDB (lumi databridge)