### PR TITLE
Fix/GJ-54 'ExtractionResult' object has no attribute '_view_masks_flat'

### DIFF
--- a/pygribjump/src/pygribjump/pygribjump.py
+++ b/pygribjump/src/pygribjump/pygribjump.py
@@ -265,7 +265,6 @@ class ExtractionSingleIterator (ExtractionIterator):
         iterator = ffi.new('gribjump_extractioniterator_t**')
         lib.gribjump_extract_single(gribjump, c_reqstr, c_ranges, c_ranges_size, c_hash, ctx, iterator)
         self.__iterator = ffi.gc(iterator[0], lib.gribjump_extractioniterator_delete)
-
     
     def __iter__(self):
         """

--- a/pygribjump/tests/test_pygribjump.py
+++ b/pygribjump/tests/test_pygribjump.py
@@ -65,6 +65,10 @@ def validate_masks(result : ExtractionResult):
             else:
                 assert not np.isnan(val)
 
+    # Check that the flattened mask's values are as expected
+    assert np.array_equal(np.concatenate(result.values), result.values_flat, equal_nan=True)
+    assert np.array_equal(np.concatenate(result.masks), result.masks_flat, equal_nan=True)
+
 @pytest.fixture(scope="function")
 def read_only_fdb_setup(data_path: pathlib.Path, tmp_path: pathlib.Path) -> pathlib.Path:
     """

--- a/pygribjump/tests/test_pygribjump.py
+++ b/pygribjump/tests/test_pygribjump.py
@@ -66,7 +66,6 @@ def validate_masks(result : ExtractionResult):
                 assert not np.isnan(val)
 
     # Check that the flattened mask's values are as expected
-    assert np.array_equal(np.concatenate(result.values), result.values_flat, equal_nan=True)
     assert np.array_equal(np.concatenate(result.masks), result.masks_flat, equal_nan=True)
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
Accessing `ExtractionResult.masks_flat` currently raises an error since it internally calls `self._view_values_flat()` which does not exist. 

This PR proposes a fix which simply involves creating an implementation of that function that's largely copy-pasted from the related `ExtractionResult.values_flat` method.