### PR TITLE
Add ExtractionRequest.indices method and ExtractionRequest.ranges property

### DIFF
--- a/pygribjump/src/pygribjump/pygribjump.py
+++ b/pygribjump/src/pygribjump/pygribjump.py
@@ -130,6 +130,7 @@ class ExtractionRequest:
         The ranges to extract.
     """
     def __init__(self, req: dict[str, str], ranges: list[tuple[int, int]], gridHash: str = None):
+        self.__ranges = ranges
         self.__shape = []
         reqstr = dic_to_request(req)
         request = ffi.new('gribjump_extraction_request_t**')
@@ -140,12 +141,18 @@ class ExtractionRequest:
         c_ranges = ffi.new('size_t[]', len(ranges)*2)
         c_ranges_size = len(ranges)*2
         for i, r in enumerate(ranges):
+            if not r[0] < r[1]:
+                raise ValueError(f"Found invalid range {r}: Expected lo < hi for ranges [lo, hi).")
             c_ranges[i*2] = r[0]
             c_ranges[i*2+1] = r[1]
             self.__shape.append(r[1] - r[0])
 
         lib.gribjump_new_request(request, c_reqstr, c_ranges, c_ranges_size, c_hash)
         self.__request = ffi.gc(request[0], lib.gribjump_delete_request)
+
+    @property
+    def ranges(self):
+        return self.__ranges
 
     @classmethod
     def from_mask(cls, req: dict[str, str], mask: np.ndarray, gridHash: str = None):
@@ -182,6 +189,14 @@ class ExtractionRequest:
     @property
     def ctype(self):
         return self.__request
+
+    def indices(self) -> np.ndarray:
+        """
+        Return a 1d array with the indices of the values that would be retrieved.
+        """
+        total = sum(self.__shape)
+        idx_iter = (idx for low, high in self.__ranges for idx in range(low, high))
+        return np.fromiter(idx_iter, int, count=total)
 
 
 class ExtractionIterator:

--- a/pygribjump/tests/test_pygribjump.py
+++ b/pygribjump/tests/test_pygribjump.py
@@ -316,3 +316,25 @@ def test_axes(read_only_fdb_setup) -> None:
     assert len(ax1.keys()) == 6
     assert len(ax2.keys()) == 8
     assert len(ax3.keys()) == 11
+
+@pytest.mark.parametrize("ranges,indices", [
+    ([], []),
+    ([(1,2)], [1]),
+    ([(1,2), (1,3)], [1, 1, 2]), # Should fail during retrieval, kept for documentation
+    ([(0, 5), (11, 12), (12, 13)], [0, 1, 2, 3, 4, 11, 12])
+])
+def test_extraction_request_indices(ranges, indices):
+    request = ExtractionRequest({"a": "b"}, ranges)
+
+    arr_expected_indices = np.array(indices, dtype=int)
+    arr_observed_indices = request.indices()
+
+    assert request.ranges == ranges
+    np.testing.assert_array_equal(arr_observed_indices, arr_expected_indices)
+
+def test_extraction_request_errors_for_invalid_range():
+    with pytest.raises(ValueError, match='invalid range'):
+        ExtractionRequest({"a": "b"}, [(2, 2)])
+
+    with pytest.raises(ValueError, match='invalid range'):
+        ExtractionRequest({"a": "b"}, [(1, 2), (4, 2)])


### PR DESCRIPTION
## Summary

This PR proposes the introduction of an `ExtractionRequest.indices()` method, which provides a flattened 1D array of indices corresponding to the requested ranges. This change would simplify access to the indices of values to be retrieved.  
Additionally, we could provide easy access to the original ranges list via a newly proposed `ExtractionRequest.ranges` property.

## Key Changes

- **`indices()` Method**: Introduces a convenient way to retrieve flattened indices as a 1D NumPy array.
- **`ranges` Property**: Adds access to the underlying c array of ranges.
- **Range Validation**: Ensures ranges are valid by requiring `hi > lo` in the `[lo, hi)` format.

## Breaking Changes

- Invalid ranges passed to the constructor now raise a `ValueError`.
