### PR TITLE
Polytope interface bug

### DIFF
--- a/pygribjump/src/pygribjump/pygribjump.py
+++ b/pygribjump/src/pygribjump/pygribjump.py
@@ -445,7 +445,7 @@ class GribJump:
             else:
                 raise ValueError(
                     "Polyrequest should be a list of tuples of length 2 or 3")
-            requests.append(ExtractionRequest(reqstr, [ranges], hash))
+            requests.append(ExtractionRequest(reqstr, list(ranges), hash))
         return requests
 
     def axes(self, req: dict[str, str], level: int = 3, ctx: str = None) -> dict[str, list[str]]:


### PR DESCRIPTION
Fix error where when we unpack polyrequest, we do not have the right object in ExtractionRequest initialisation. Otherwise, we get this error in Polytope: 

  File "polytope/polytope_feature/datacube/backends/fdb.py", line 154, in get
    iterator = self.gj.extract(complete_list_complete_uncompressed_requests, context)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "polytope_quadtree_performance/quadtree_polytope_venv/lib/python3.12/site-packages/pygribjump/pygribjump.py", line 345, in extract
    requests = self._unpack_polyrequest(polyrequest)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "polytope_quadtree_performance/quadtree_polytope_venv/lib/python3.12/site-packages/pygribjump/pygribjump.py", line 420, in _unpack_polyrequest
    requests.append(ExtractionRequest(reqstr, ranges, hash))
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "polytope_quadtree_performance/quadtree_polytope_venv/lib/python3.12/site-packages/pygribjump/pygribjump.py", line 137, in __init__
    self.__ranges = ranges.copy()
                    ^^^^^^^^^^^
AttributeError: 'tuple' object has no attribute 'copy'