### PR TITLE
Support insertion into existing .gribjump files using scan-files tool

### DIFF
--- a/src/gribjump/info/InfoCache.h
+++ b/src/gribjump/info/InfoCache.h
@@ -16,6 +16,7 @@
 #include <map>
 
 #include "eckit/filesystem/URI.h"
+#include "eckit/io/Offset.h"
 #include "eckit/serialisation/FileStream.h"
 #include "eckit/serialisation/Stream.h"
 
@@ -43,7 +44,9 @@ public:
     /// @param offsets list of offsets to at which GribInfo should be extracted
     size_t scan(const eckit::PathName& path, const std::vector<eckit::Offset>& offsets);
 
-    size_t scan(const eckit::PathName& path);  // < scan all fields in a file
+    // if merge is true, we only generate jumpinfos for offsets that are not already in the cache file
+    // if merge is false, we generate an entirely new cache file
+    size_t scan(const eckit::PathName& path, bool merge = true);  // < scan all fields in a file
 
 
     /// Inserts a JumpInfo entry
@@ -146,6 +149,14 @@ private:  // Methods are only intended to be called from InfoCache
     void unlock() { mutex_.unlock(); }
 
     const infomap_t& map() const { return map_; }
+
+    eckit::OffsetList offsets() const {
+        eckit::OffsetList offsets;
+        for (const auto& entry : map_) {
+            offsets.push_back(entry.first);
+        }
+        return offsets;
+    }
 
 private:
 

--- a/src/gribjump/info/InfoExtractor.h
+++ b/src/gribjump/info/InfoExtractor.h
@@ -31,12 +31,16 @@ public:
     ~InfoExtractor();
 
 
-    std::vector<std::pair<eckit::Offset, std::unique_ptr<JumpInfo>>> extract(const eckit::PathName& path);
-    std::vector<std::unique_ptr<JumpInfo>> extract(const eckit::PathName& path,
-                                                   const std::vector<eckit::Offset>& offsets);
-    std::unique_ptr<JumpInfo> extract(const eckit::PathName& path, const eckit::Offset& offset);
+    std::vector<std::pair<eckit::Offset, std::unique_ptr<JumpInfo>>> extract(const eckit::PathName& path) const;
 
-    std::unique_ptr<JumpInfo> extract(const eckit::message::Message& msg);
+    std::vector<std::unique_ptr<JumpInfo>> extract(const eckit::PathName& path,
+                                                   const std::vector<eckit::Offset>& offsets) const;
+
+    std::unique_ptr<JumpInfo> extract(const eckit::PathName& path, const eckit::Offset& offset) const;
+
+    std::unique_ptr<JumpInfo> extract(const eckit::message::Message& msg) const;
+
+    eckit::OffsetList offsets(const eckit::PathName& path) const;
 };
 
 }  // namespace gribjump

--- a/src/tools/gribjump-scan-files.cc
+++ b/src/tools/gribjump-scan-files.cc
@@ -8,6 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
+#include "eckit/exception/Exceptions.h"
 #include "fdb5/api/FDB.h"
 
 #include "gribjump/GribJump.h"
@@ -15,7 +16,7 @@
 
 /// @author Christopher Bradley
 
-/// Tool to execute to scan a set of files to built a GribJump info index.
+/// Tool to scan a set of files to built a GribJump info index. Assumes that the files are local.
 /// Output directory is specified in the configuration file.
 
 namespace gribjump::tool {
@@ -29,12 +30,15 @@ class ScanFiles : public GribJumpTool {  // dont use fdb tool
 public:
 
     ScanFiles(int argc, char** argv) : GribJumpTool(argc, argv, "gribjump-scan-files") {
+        options_.push_back(
+            new eckit::option::SimpleOption<bool>("skipExisting",
+                                                  "If true, ignore existing .gribjump files (otherwise we check "
+                                                  "existing .gribjump files for missing fields). Default false."));
+        // options_.push_back(new eckit::option::SimpleOption<bool>(
+        //     "regenerate", "If true, regenerate .gribjump files from scratch, potentially overwriting existing
+        //     .gribjump files. Default false."));
         options_.push_back(new eckit::option::SimpleOption<bool>(
-            "overwrite", "If true, overwrite existing .gribjump files instead of skipping. Default false."));
-        options_.push_back(new eckit::option::SimpleOption<bool>(
-            "merge", "If true, merge jumpinfos with existing .gribjump files instead of skipping. Default false."));
-        options_.push_back(new eckit::option::SimpleOption<bool>(
-            "dry-run", "If true, do not write the .gribjump files. Default false."));
+            "dry-run", "If true, do not scan anything, just list the files we would scan. Default false."));
     }
 };
 
@@ -46,17 +50,14 @@ void ScanFiles::usage(const std::string& tool) const {
 
 void ScanFiles::execute(const eckit::option::CmdArgs& args) {
 
-    bool overwrite = args.getBool("overwrite", false);
-    bool merge     = args.getBool("merge", false);
-    bool dryrun    = args.getBool("dry-run", false);
+    bool skipExisting = args.getBool("skipExisting", false);
+    // bool regenerate       = args.getBool("regenerate", false);
+    bool regenerate = false;  // NOTIMP
+    bool dryrun     = args.getBool("dry-run", false);
     std::vector<std::string> files_in(args.begin(), args.end());
 
-    if (overwrite && merge) {
-        throw eckit::UserError("Cannot specify both --overwrite and --merge");
-    }
-
-    if (merge || overwrite) {
-        NOTIMP;  // later...
+    if (skipExisting && regenerate) {
+        throw eckit::UserError("Cannot use both --skipExisting and --regenerate options at the same time.");
     }
 
     if (files_in.empty()) {
@@ -66,7 +67,7 @@ void ScanFiles::execute(const eckit::option::CmdArgs& args) {
 
     // Check each file exists, and also check if corresponding the .gribjump file exists.
     std::vector<eckit::PathName> files_scan;
-    std::vector<eckit::PathName> files_skip;
+    std::vector<eckit::PathName> files_existing;
 
     for (const std::string& file : files_in) {
         eckit::PathName path(file);
@@ -75,19 +76,30 @@ void ScanFiles::execute(const eckit::option::CmdArgs& args) {
         }
 
         eckit::PathName index = path + ".gribjump";
-        if (index.exists() && !overwrite && !merge) {
-            files_skip.push_back(path);
+        if (index.exists()) {
+            files_existing.push_back(path);
         }
         else {
             files_scan.push_back(path);
         }
     }
 
-    if (!files_skip.empty()) {
-        eckit::Log::info() << "Skipping files with existing .gribjump files (use --overwrite option to regenerate):"
-                           << std::endl;
-        for (const eckit::PathName& path : files_skip) {
+    if (!files_existing.empty()) {
+        eckit::Log::info() << ".gribjump files exist for the following files:" << std::endl;
+        for (const eckit::PathName& path : files_existing) {
             eckit::Log::info() << "  " << path << std::endl;
+        }
+
+        if (skipExisting) {
+            eckit::Log::info() << "Skipping these files as --skipExisting option is set." << std::endl;
+        }
+        else if (regenerate) {
+            eckit::Log::info() << "These will be overwritten as --regenerate option is set." << std::endl;
+            files_scan.insert(files_scan.end(), files_existing.begin(), files_existing.end());
+        }
+        else {
+            eckit::Log::info() << "These files will be modified if they are found to be missing fields." << std::endl;
+            files_scan.insert(files_scan.end(), files_existing.begin(), files_existing.end());
         }
     }
 
@@ -103,6 +115,11 @@ void ScanFiles::execute(const eckit::option::CmdArgs& args) {
 
     if (dryrun)
         return;
+
+    if (regenerate) {
+        /// @todo: Instruction to regenerate needs to be propagated to the InfoCache.
+        NOTIMP;
+    }
 
     GribJump gj;
     gj.scan(files_scan, ctx_);  // take merge/overwrite into account?


### PR DESCRIPTION
Previously, the gribjump-scan-files tool skipped files if a corresponding .gribjump file exists. However, it is possible (and is the case on the databridge) that the .gribjump only indexes a subset of the corresponding data file.

This PR modifies gribjump-scan-files so that it can check for missing entries in the .gribjump file, and insert them accordingly.
