### PR TITLE
fix: update setuptools version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ dependencies = [
     "cffi~=1.17",
     "numpy~=1.26",
     "pytest~=8.3",
-    "setuptools~=75.1",
     "findlibs~=0.1.1",
     "packaging>=20.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ testpaths = [
 # pyproject.toml
 
 [build-system]
-requires = ["setuptools>=65", "setuptools-scm"]
+requires = ["setuptools>=77.0.3", "setuptools-scm"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
### Description

As part of other changes, the PR https://github.com/ecmwf/gribjump/pull/61 added two new lines to the central `pyproject.toml`:

```
license = "Apache-2.0"
license-files = ["LICENSE"]
```

These were introduced with [PEP 639](https://peps.python.org/pep-0639/) and are supported by `setuptools` versions since 77.0.3 ([source](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files)).

In the `pyproject.toml`'s `dependencies` section however, `setuptools` is currently pinned to `~=75.1`. This version mismatch can break downstream build tools since the resolved `setuptools` version cannot deal with these fields correctly. This happened to me when I tried to build gribjump for a recent commit. 

This PR proposes two related changes:
1. Increase the minimum required setuptools version in `build-system.requires` to accurately represent the actually required version.
2. Remove the pinned setuptools version from `project.dependencies`, which ultimately triggered the issue. I'm not 100% sure if this is safe to do or if there's any part in `pygribjump` that requires setuptools. Alternatively we could just also update the version here but if there's no reason to keep it, I'd suggest we simply remove it.

Of course, we could also just use the old license fields (`license = { text = "Apache License Version 2.0" }`) if there's some reason, we wouldn't want to update the `setuptools` version. Please let me know if you have any concerns about this. Would the downstream-ci system notify us if this would break some other package?

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 