### PR TITLE
[gribjumplib] handle lib?64 in cmake defs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ testpaths = [
 # pyproject.toml
 
 [build-system]
-requires = ["setuptools>=77.0.3", "setuptools-scm"]
+requires = ["setuptools>=77.0.3"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/python/gribjumplib/buildconfig
+++ b/python/gribjumplib/buildconfig
@@ -12,7 +12,9 @@
 
 NAME="gribjump"
 
-CMAKE_PARAMS="-Deckit_ROOT=/tmp/gribjump/prereqs/eckitlib -Deccodes_ROOT=/tmp/gribjump/prereqs/eccodeslib -Dmetkit_ROOT=/tmp/gribjump/prereqs/metkitlib -Dfdb5_ROOT=/tmp/gribjump/prereqs/fdb5lib -DAEC_INCLUDE_DIR=/tmp/gribjump/prereqs/eccodeslib/include -DAEC_LIBRARY=/tmp/gribjump/prereqs/eccodeslib/lib64"
+if [ "$(uname)" != "Darwin" ] ; then LIB=lib64 ; else LIB=lib ; fi
+
+CMAKE_PARAMS="-Deckit_ROOT=/tmp/gribjump/prereqs/eckitlib -Deccodes_ROOT=/tmp/gribjump/prereqs/eccodeslib -Dmetkit_ROOT=/tmp/gribjump/prereqs/metkitlib -Dfdb5_ROOT=/tmp/gribjump/prereqs/fdb5lib -DAEC_INCLUDE_DIR=/tmp/gribjump/prereqs/eccodeslib/include -DAEC_LIBRARY=/tmp/gribjump/prereqs/eccodeslib/$LIB"
 
 PYPROJECT_DIR="python/gribjumplib"
 DEPENDENCIES='["eckitlib", "eccodeslib", "metkitlib", "fdb5lib"]'

--- a/python/gribjumplib/buildconfig
+++ b/python/gribjumplib/buildconfig
@@ -12,9 +12,7 @@
 
 NAME="gribjump"
 
-if [ "$(uname)" != "Darwin" ] ; then LIB=lib64 ; else LIB=lib ; fi
-
-CMAKE_PARAMS="-Deckit_ROOT=/tmp/gribjump/prereqs/eckitlib -Deccodes_ROOT=/tmp/gribjump/prereqs/eccodeslib -Dmetkit_ROOT=/tmp/gribjump/prereqs/metkitlib -Dfdb5_ROOT=/tmp/gribjump/prereqs/fdb5lib -DAEC_INCLUDE_DIR=/tmp/gribjump/prereqs/eccodeslib/include -DAEC_LIBRARY=/tmp/gribjump/prereqs/eccodeslib/$LIB"
+CMAKE_PARAMS="-Deckit_ROOT=/tmp/gribjump/prereqs/eckitlib -Deccodes_ROOT=/tmp/gribjump/prereqs/eccodeslib -Dmetkit_ROOT=/tmp/gribjump/prereqs/metkitlib -Dfdb5_ROOT=/tmp/gribjump/prereqs/fdb5lib -Dlibaec_ROOT=/tmp/gribjump/prereqs/eccodeslib"
 
 PYPROJECT_DIR="python/gribjumplib"
 DEPENDENCIES='["eckitlib", "eccodeslib", "metkitlib", "fdb5lib"]'


### PR DESCRIPTION
the dir structure in wheels differs based on platforms, because thats the default compilation output, in turn causing cmake to complain about missing targets. Fixing

additionally a minor fix on the pyproject.toml to remove the presumably misplaced setuptools-scm dependency

verified in https://github.com/ecmwf/python-develop-bundle/actions/runs/17270134778/job/49012307749