### PR TITLE
Feature/corrupted scan

### DIFF
--- a/scripts/corrupted_scan.sh
+++ b/scripts/corrupted_scan.sh
@@ -55,7 +55,7 @@ if [ "$eccodes_count" -eq 0 ]; then
     exit 0
 fi
 
-GRIBJUMP_SCAN_CORRUPTED=1 gribjump-scan-files $gribfile
+GRIBJUMP_SCAN_CORRUPTED=1 gribjump-scan-files $gribfile &> /dev/null
 
 # sanity check results
 if [ ! -f "$outfile" ]; then
@@ -71,5 +71,5 @@ if [ "$count_gribjump" -ne "$eccodes_count" ]; then
     exit 1
 fi
 
-echo "Successfully created gribjump index file: $outfile with $count_gribjump messages"
+echo "Created index file: $outfile with $count_gribjump entries"
 exit 0

--- a/scripts/corrupted_scan.sh
+++ b/scripts/corrupted_scan.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+# For scanning corrupted GRIB files and generating gribjump index
+# We assume that the tail of a GRIB file is corrupted in the following way:
+# - It contains a message that starts with "GRIB" but does not end with "7777"
+# - This message is at the end of the file
+# - All other messages in the file are valid.
+# This script will give spurious results if the file does not follow this pattern.
+
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 <gribfile>"
+    exit 1
+fi
+
+gribfile=$1
+outfile="$gribfile.gribjump"
+
+# Assert that it does not already exist
+if [ -f "$outfile" ]; then
+    echo "Output file $outfile already exists. Please remove it before running this script."
+    exit 1
+fi
+
+eccodes_count_messages() {
+    local output
+    output=$(grib_count $gribfile 2>&1)
+
+    if [[ "$output" =~ ^[0-9]+$ ]]; then
+        echo "$output"
+        return 0
+    fi
+
+    local count
+    count=$(echo "$output" | grep -oE 'got as far as [0-9]+' | grep -oE '[0-9]+')
+
+    if [[ -n "$count" ]]; then
+        echo "$count"
+        return 0
+    fi
+
+    echo "Error: Unable to extract count from grib_count output" >&2
+    return 1
+}
+
+# Get count from eccodes
+eccodes_count=$(eccodes_count_messages)
+if [ $? -ne 0 ]; then
+    echo "Failed to get count from grib_count"
+    exit 1
+fi
+
+# if eccodes_count is 0, we can exit early
+if [ "$eccodes_count" -eq 0 ]; then
+    echo "No GRIB messages found in $gribfile"
+    exit 0
+fi
+
+GRIBJUMP_SCAN_CORRUPTED=1 gribjump-scan-files $gribfile
+
+# sanity check results
+if [ ! -f "$outfile" ]; then
+    echo "Failed to create gribjump index file: $outfile"
+    exit 1
+fi
+
+count_gribjump=$(grep -c "Info" "$outfile")
+
+# check gribjump and eccodes agree
+if [ "$count_gribjump" -ne "$eccodes_count" ]; then
+    echo "Mismatch in counts: gribjump found $count_gribjump messages, eccodes found $eccodes_count messages"
+    exit 1
+fi
+
+echo "Successfully created gribjump index file: $outfile with $count_gribjump messages"
+exit 0

--- a/tests/tools/CMakeLists.txt
+++ b/tests/tools/CMakeLists.txt
@@ -1,6 +1,7 @@
 list( APPEND gribjump_test_tools_data
 supported.grib
 unsupported.grib
+# corrupted.grib # TODO put on nexus
 )
 
 # TODO: Make this check md5sum. Removing NOCHECK seems to not pull the data at all...
@@ -12,5 +13,14 @@ ecbuild_add_test(
     TARGET   gribjump_callback_vs_scan
     TYPE     SCRIPT
     COMMAND  gribjump_callback_vs_scan.sh
+    TEST_DEPENDS gribjump_test_tools_data
+)
+
+ecbuild_configure_file( scan_corrupted.sh.in gribjump_scan_corrupted.sh @ONLY )
+
+ecbuild_add_test(
+    TARGET   gribjump_scan_corrupted
+    TYPE     SCRIPT
+    COMMAND  gribjump_scan_corrupted.sh
     TEST_DEPENDS gribjump_test_tools_data
 )

--- a/tests/tools/CMakeLists.txt
+++ b/tests/tools/CMakeLists.txt
@@ -1,7 +1,7 @@
 list( APPEND gribjump_test_tools_data
 supported.grib
 unsupported.grib
-# corrupted.grib # TODO put on nexus
+corrupted.grib
 )
 
 # TODO: Make this check md5sum. Removing NOCHECK seems to not pull the data at all...

--- a/tests/tools/scan_corrupted.sh.in
+++ b/tests/tools/scan_corrupted.sh.in
@@ -23,8 +23,7 @@ bindir=@CMAKE_CURRENT_BINARY_DIR@
 
 # Data from nexus
 # This file contains 1 complete message followed by 1 incomplete message (starts with GRIB but does not end with 7777)
-# datafile="$bindir/corrupted.grib" # LOCAL FOR NOW
-datafile="$srcdir/corrupted.grib" # LOCAL FOR NOW
+datafile="$bindir/corrupted.grib"
 
 # expect to fail by default
 set +e

--- a/tests/tools/scan_corrupted.sh.in
+++ b/tests/tools/scan_corrupted.sh.in
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# -- Description ----------------------------------------------------------
+# This script tests gribjump's jumpinfo generation and interaction with fdb. It writes to four fdbs:
+#   1. FDB archive, no gribjump plugin and no gribjump index.
+#   2. FDB archive, no gribjump plugin, but a gribjump-scan (with a mars request) is run afterwards to generate gribjump index.
+#   3. FDB archive, with gribjump plugin to automatically generate the gribjump index.
+#   4. FDB archive, with gribjump-scan-files to generate gribjump index from a list of files.
+#   5. grib2fdb with gribjump plugin enabled.
+# Then, we perform the same extraction on all fdbs and check for consistency.
+# The test data contains several grib messages with different packing types, some supported some not.
+
+# -- Environment --------------------------------------------------------------
+set -ex
+
+gjscanfiles="$<TARGET_FILE:gribjump-scan-files>"
+gjdump="$<TARGET_FILE:gribjump-dump-info>"
+
+srcdir=@CMAKE_CURRENT_SOURCE_DIR@
+bindir=@CMAKE_CURRENT_BINARY_DIR@
+
+
+# -- Setup ---------------------------------------------------------------
+
+# Data from nexus
+# This file contains 1 complete message followed by 1 incomplete message (starts with GRIB but does not end with 7777)
+# datafile="$bindir/corrupted.grib" # LOCAL FOR NOW
+datafile="$srcdir/corrupted.grib" # LOCAL FOR NOW
+
+# expect to fail by default
+set +e
+$gjscanfiles $datafile
+if [ $? -eq 0 ]; then
+    echo "Expected scan failure for corrupted data, but succeeded..."
+    exit 1
+fi
+echo "Failed as expected for corrupted data"
+set -e
+
+GRIBJUMP_SCAN_CORRUPTED=1 $gjscanfiles $datafile
+
+# expect corrupted.grib.gribjump to be created
+if [ ! -f "$datafile.gribjump" ]; then
+    echo "Failed to create gribjump index file: $datafile.gribjump"
+    exit 1
+fi
+
+count=$($gjdump $datafile.gribjump | grep -c "Info")
+
+# expect count to be 1
+if [ "$count" -ne 1 ]; then
+    echo "Failed to find 1 grib message in $datafile.gribjump, found $count"
+    exit 1
+fi
+
+rm -f "$datafile.gribjump"
+
+echo "Test finished"


### PR DESCRIPTION
Update the gribjump-scan-files tool to be able to scan files in which the final GRIB message is incomplete (has no 7777).