### PR TITLE
Fix/gj 60 logcontext

### DIFF
--- a/src/gribjump/Engine.cc
+++ b/src/gribjump/Engine.cc
@@ -292,7 +292,6 @@ TaskOutcome<size_t> Engine::scheduleScanTasks(const scanmap_t& scanmap) {
 }
 
 std::map<std::string, std::unordered_set<std::string>> Engine::axes(const std::string& request, int level) {
-    MetricsManager::instance().set("request", request);
     return FDBLister::instance().axes(request, level);
 }
 

--- a/src/gribjump/Lister.cc
+++ b/src/gribjump/Lister.cc
@@ -15,6 +15,7 @@
 
 #include "gribjump/GribJumpException.h"
 #include "gribjump/Lister.h"
+#include "gribjump/Metrics.h"
 #include "gribjump/URIHelper.h"
 
 namespace gribjump {
@@ -85,6 +86,8 @@ std::string fdbkeyToStr(const fdb5::Key& key) {
 // i.e. do all of the listing work I want...
 filemap_t FDBLister::fileMap(const metkit::mars::MarsRequest& unionRequest, const ExItemMap& reqToExtractionItem) {
     filemap_t filemap;
+
+    MetricsManager::instance().addRequest(unionRequest);
 
     fdb5::FDBToolRequest fdbreq(unionRequest);
 
@@ -228,7 +231,10 @@ std::map<std::string, std::unordered_set<std::string>> FDBLister::axes(const std
         fdb5::FDBToolRequest::requestsFromString(request, std::vector<std::string>(), true);
     ASSERT(requests.size() == 1);  // i.e. assume string is a single request.
 
-    return axes(requests.front(), level);
+    const fdb5::FDBToolRequest& r = requests.front();
+    MetricsManager::instance().addRequest(r.request());
+
+    return axes(r, level);
 }
 
 std::map<std::string, std::unordered_set<std::string>> FDBLister::axes(const fdb5::FDBToolRequest& request, int level) {

--- a/src/gribjump/Metrics.cc
+++ b/src/gribjump/Metrics.cc
@@ -14,6 +14,7 @@
 #include "eckit/log/Log.h"
 #include "eckit/runtime/Main.h"
 #include "gribjump/LibGribJump.h"
+#include "metkit/mars/MarsRequest.h"
 
 namespace {
 std::string iso(time_t t) {
@@ -38,6 +39,10 @@ void Metrics::add(const std::string& name, const eckit::Value& value) {
     values_[name] = value;
 }
 
+void Metrics::addRequest(const metkit::mars::MarsRequest& request) {
+    fdbRequests_.push_back(request);
+}
+
 void Metrics::report() {
 
     time_t now = std::time(nullptr);
@@ -50,10 +55,17 @@ void Metrics::report() {
     j << "start_time" << iso(created_);
     j << "end_time" << iso(now);
     j << "run_time" << timer_.elapsed();
-
     for (const auto& [name, value] : values_) {
         j << name << value;
     }
+
+    j << "mars_requests";
+    j.startList();
+    for (auto& request : fdbRequests_) {
+        request.json(j);
+    }
+    j.endList();
+
     j << "context" << ContextManager::instance().context();
     j.endObject();
 
@@ -74,6 +86,10 @@ MetricsManager::~MetricsManager() {}
 
 void MetricsManager::set(const std::string& name, const eckit::Value& value) {
     metrics().add(name, value);
+}
+
+void MetricsManager::addRequest(const metkit::mars::MarsRequest& request) {
+    metrics().addRequest(request);
 }
 
 Metrics& MetricsManager::metrics() {

--- a/src/gribjump/Metrics.h
+++ b/src/gribjump/Metrics.h
@@ -18,6 +18,7 @@
 #include "eckit/parser/JSONParser.h"
 #include "eckit/runtime/Metrics.h"
 #include "eckit/serialisation/Stream.h"
+#include "metkit/mars/MarsRequest.h"
 
 namespace gribjump {
 
@@ -37,9 +38,7 @@ public:
 
     explicit LogContext(eckit::Stream& s) { s >> context_; }
 
-    void json(eckit::JSON& s) const { 
-        s << eckit::JSONParser::decodeString(context_);
-    }
+    void json(eckit::JSON& s) const { s << eckit::JSONParser::decodeString(context_); }
 
     ~LogContext() {}
 
@@ -80,19 +79,18 @@ public:  // methods
 
     void add(const std::string& name, const eckit::Value& value);
 
+    void addRequest(const metkit::mars::MarsRequest& request);
+
     void addContext(const LogContext& context) { context_ = context; }
 
     void report();
-
-public:  // members
-
-    eckit::ValueMap values_;
 
 private:  // members
 
     LogContext context_;
     time_t created_;
-
+    eckit::ValueMap values_;
+    std::vector<metkit::mars::MarsRequest> fdbRequests_;
     eckit::Timer timer_;
 };
 
@@ -105,7 +103,9 @@ public:  // methods
     static MetricsManager& instance();
 
     void set(const std::string& name, const eckit::Value& value);
-    // void setContext(const LogContext& context);
+
+    void addRequest(const metkit::mars::MarsRequest& request);
+
     void report();
 
 private:

--- a/src/gribjump/Metrics.h
+++ b/src/gribjump/Metrics.h
@@ -37,6 +37,10 @@ public:
 
     explicit LogContext(eckit::Stream& s) { s >> context_; }
 
+    void json(eckit::JSON& s) const { 
+        s << eckit::JSONParser::decodeString(context_);
+    }
+
     ~LogContext() {}
 
 private:
@@ -47,8 +51,6 @@ private:
         o.encode(s);
         return s;
     }
-
-    void json(eckit::JSON& s) const { s << context_; }
 
     friend eckit::JSON& operator<<(eckit::JSON& s, const LogContext& o) {
         o.json(s);

--- a/src/gribjump/Task.cc
+++ b/src/gribjump/Task.cc
@@ -251,6 +251,8 @@ ForwardExtractionTask::ForwardExtractionTask(TaskGroup& taskgroup, const size_t 
 
 void ForwardExtractionTask::executeImpl() {
 
+    ContextManager::instance().set(taskGroup_.context());
+
     RemoteGribJump remoteGribJump(endpoint_);
     remoteGribJump.forwardExtract(filemap_);
 }
@@ -266,6 +268,8 @@ ForwardScanTask::ForwardScanTask(TaskGroup& taskgroup, const size_t id, eckit::n
     Task(taskgroup, id), endpoint_(endpoint), scanmap_(scanmap), nfields_(nfields) {}
 
 void ForwardScanTask::executeImpl() {
+
+    ContextManager::instance().set(taskGroup_.context());
 
     RemoteGribJump remoteGribJump(endpoint_);
     nfields_ += remoteGribJump.forwardScan(scanmap_);

--- a/src/gribjump/Task.h
+++ b/src/gribjump/Task.h
@@ -97,7 +97,7 @@ private:
 class TaskGroup {
 public:
 
-    TaskGroup() = default;
+    TaskGroup(): ctx_{ContextManager::instance().context()} {}
 
     /// Notify that a task has been completed
     void notify(size_t taskid);
@@ -137,6 +137,8 @@ public:
 
     void info() const;
 
+    const LogContext& context() const {return ctx_;}
+
 private:
 
     void enqueueTask(Task* task);
@@ -157,6 +159,8 @@ private:
 
     std::vector<std::shared_ptr<Task>> tasks_;
     std::vector<std::string> errors_;  //< stores error messages, empty if no errors
+
+    const LogContext& ctx_;  //< required for propagating context in forwarding tasks.
 };
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/src/gribjump/Task.h
+++ b/src/gribjump/Task.h
@@ -97,7 +97,7 @@ private:
 class TaskGroup {
 public:
 
-    TaskGroup(): ctx_{ContextManager::instance().context()} {}
+    TaskGroup() : ctx_{ContextManager::instance().context()} {}
 
     /// Notify that a task has been completed
     void notify(size_t taskid);
@@ -137,7 +137,7 @@ public:
 
     void info() const;
 
-    const LogContext& context() const {return ctx_;}
+    const LogContext& context() const { return ctx_; }
 
 private:
 

--- a/src/gribjump/remote/Request.cc
+++ b/src/gribjump/remote/Request.cc
@@ -29,7 +29,7 @@ namespace gribjump {
 
 Request::Request(eckit::Stream& stream) : client_(stream) {
     id_ = requestid();
-    MetricsManager::instance().set("request_id", id_);
+    MetricsManager::instance().set("gribjump_request_id", id_);
 }
 
 void Request::reportErrors() {
@@ -54,7 +54,7 @@ ScanRequest::ScanRequest(eckit::Stream& stream) : Request(stream) {
         requests_.emplace_back(metkit::mars::MarsRequest(client_));
     }
 
-    MetricsManager::instance().set("count_requests", numRequests);
+    MetricsManager::instance().set("count_scan_requests", numRequests);
 }
 
 void ScanRequest::execute() {
@@ -88,7 +88,7 @@ ExtractRequest::ExtractRequest(eckit::Stream& stream) : Request(stream) {
         requests_.push_back(req);
     }
 
-    MetricsManager::instance().set("count_requests", nRequests);
+    MetricsManager::instance().set("count_extraction_requests", nRequests);
 }
 
 void ExtractRequest::execute() {
@@ -156,7 +156,7 @@ ForwardedExtractRequest::ForwardedExtractRequest(eckit::Stream& stream) : Reques
         }
         count += nItems;
     }
-    MetricsManager::instance().set("count_requests", count);
+    MetricsManager::instance().set("count_extraction_requests", count);
 
     ASSERT(count > 0);  // We should not be talking to this server if we have no requests.
 }


### PR DESCRIPTION
### Description

Simple reformatting of logs, see gj-60.

Updates "metrics" logs to:
- show any mars requests sent to fdb (gribjump.axes and gribjump.extract)
- properly serialise the context object as json, not a string
- properly forward the context to servers when doing a forward extraction.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 