### PR TITLE
Deprecate NonCopyable in favour of explicitly deleted ctors

### DIFF
--- a/src/gribjump/ExtractionItem.h
+++ b/src/gribjump/ExtractionItem.h
@@ -26,7 +26,7 @@ namespace gribjump {
 // An object for grouping request, uri and result information together.
 /// @todo: Recently reworked. Code which uses this object could be refactored to have less moving of vectors to and from
 /// this object.
-class ExtractionItem : public eckit::NonCopyable {
+class ExtractionItem {
 
 public:
 
@@ -36,6 +36,11 @@ public:
     // Because sometimes we dont use marsrequests.
     ExtractionItem(const Ranges& ranges) :
         request_{std::make_unique<ExtractionRequest>("", ranges)}, result_{std::make_unique<ExtractionResult>()} {}
+
+    ExtractionItem(const ExtractionItem&)            = delete;
+    ExtractionItem& operator=(const ExtractionItem&) = delete;
+    ExtractionItem(ExtractionItem&&)                 = default;
+    ExtractionItem& operator=(ExtractionItem&&)      = default;
 
     ~ExtractionItem() {};
 

--- a/src/gribjump/GribJumpBase.h
+++ b/src/gribjump/GribJumpBase.h
@@ -16,7 +16,6 @@
 #include <unordered_set>
 
 #include "eckit/filesystem/URI.h"
-#include "eckit/memory/NonCopyable.h"
 
 #include "gribjump/Config.h"
 #include "gribjump/ExtractionData.h"
@@ -36,11 +35,16 @@ namespace gribjump {
 ///@todo: Why is this *here*? and not in Engine
 using ResultsMap = std::map<std::string, std::unique_ptr<ExtractionItem>>;
 
-class GribJumpBase : public eckit::NonCopyable {
+class GribJumpBase {
 public:
 
     GribJumpBase(const Config& config);
     GribJumpBase();
+
+    GribJumpBase(const GribJumpBase&)            = delete;
+    GribJumpBase& operator=(const GribJumpBase&) = delete;
+    GribJumpBase(GribJumpBase&&)                 = delete;
+    GribJumpBase& operator=(GribJumpBase&&)      = delete;
 
     virtual ~GribJumpBase();
 

--- a/src/gribjump/remote/GribJumpServer.h
+++ b/src/gribjump/remote/GribJumpServer.h
@@ -23,7 +23,7 @@ namespace gribjump {
 //-------------------------------------------------------------------------------------------------
 // Maybe we don't need this class at all.  We can just use GribJumpService directly.
 
-class GribJumpServer : private eckit::NonCopyable {
+class GribJumpServer {
 public:
 
     GribJumpServer(int port) : svc_(new GribJumpService(port)), tcsvc_(svc_) {
@@ -36,6 +36,12 @@ public:
         WorkQueue::instance();  // start the work queue
         tcsvc_.start();
     }
+
+    GribJumpServer(const GribJumpServer&)            = delete;
+    GribJumpServer& operator=(const GribJumpServer&) = delete;
+    GribJumpServer(GribJumpServer&&)                 = delete;
+    GribJumpServer& operator=(GribJumpServer&&)      = delete;
+
     ~GribJumpServer() {}
 
 private:  // methods

--- a/src/gribjump/remote/WorkQueue.h
+++ b/src/gribjump/remote/WorkQueue.h
@@ -24,10 +24,15 @@ namespace gribjump {
 
 //----------------------------------------------------------------------------------------------------------------------
 
-class WorkQueue : private eckit::NonCopyable {
+class WorkQueue {
 public:
 
     static WorkQueue& instance();  // singleton
+
+    WorkQueue(const WorkQueue&)            = delete;
+    WorkQueue& operator=(const WorkQueue&) = delete;
+    WorkQueue(WorkQueue&&)                 = delete;
+    WorkQueue& operator=(WorkQueue&&)      = delete;
 
     ~WorkQueue();
 


### PR DESCRIPTION
### Description

An attempt to modernize the code base, by deprecating the "old style" NonCopyable in favour of explicitly deleting copy ctor/copy assignment operator.

This follows the advice of the CppCoreGuidelines, which states = delete is preferred -- see the discussion https://github.com/isocpp/CppCoreGuidelines/issues/1354#issuecomment-470669557.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 