### PR TITLE
Explicitly set eccodes missing value to 9999 in tests

### DIFF
--- a/src/gribjump/tools/EccodesExtract.cc
+++ b/src/gribjump/tools/EccodesExtract.cc
@@ -9,16 +9,13 @@
  */
 /// @author Christopher Bradley
 
-#include <fstream>
 #include <memory>
 
 #include "eckit/filesystem/PathName.h"
 #include "eckit/io/DataHandle.h"
-#include "eckit/utils/StringTools.h"
 
 #include "metkit/codes/api/CodesAPI.h"
 
-// #include "gribjump/FDBService.h"
 #include "gribjump/Lister.h"
 #include "gribjump/tools/EccodesExtract.h"
 
@@ -44,26 +41,6 @@ std::vector<std::vector<std::vector<double>>> eccodesExtract(metkit::mars::MarsR
     return results;
 }
 
-// Expects a request to have cardinality 1
-/// @todo: you wrote this but I dont think started to use it yet.
-std::vector<std::vector<double>> eccodesExtractSingle(metkit::mars::MarsRequest request, std::vector<Range> ranges) {
-    std::map<eckit::PathName, eckit::OffsetList> map = FDBLister::instance().filesOffsets({request});
-
-    // Should have exactly one pathname, and one element in the offset list.
-    if (map.size() != 1) {
-        throw eckit::UserError("Expected exactly one file for request: " + request.asString(), Here());
-    }
-
-    const eckit::PathName path      = map.begin()->first;
-    const eckit::OffsetList offsets = map.begin()->second;
-
-    if (offsets.size() != 1) {
-        throw eckit::UserError("Expected exactly one offset for request: " + request.asString(), Here());
-    }
-    std::vector<std::vector<double>> results = eccodesExtract(path, offsets, ranges)[0];
-    return results;
-}
-
 std::vector<std::vector<std::vector<double>>> eccodesExtract(eckit::PathName path, eckit::OffsetList offsets,
                                                              std::vector<Range> ranges) {
 
@@ -82,6 +59,7 @@ std::vector<std::vector<std::vector<double>>> eccodesExtract(eckit::PathName pat
         std::unique_ptr<metkit::codes::CodesHandle> handle = metkit::codes::codesHandleFromStream(
             [&](uint8_t* buffer, int64_t len) -> int64_t { return dh->read(buffer, len); });
 
+        handle->set("missingValue", 9999);
 
         auto data = handle->getDoubleArray("values");
 
@@ -108,6 +86,8 @@ std::vector<double> eccodesExtract(eckit::PathName path) {
     // Note: eccodes will read message into memory
     std::unique_ptr<metkit::codes::CodesHandle> handle = metkit::codes::codesHandleFromStream(
         [&](uint8_t* buffer, int64_t len) -> int64_t { return dh->read(buffer, len); });
+
+    handle->set("missingValue", 9999);
 
     return handle->getDoubleArray("values");
 }

--- a/src/gribjump/tools/EccodesExtract.h
+++ b/src/gribjump/tools/EccodesExtract.h
@@ -12,8 +12,11 @@
 #pragma once
 
 #include "eckit/filesystem/PathName.h"
-#include "gribjump/ExtractionData.h"
+#include "gribjump/Types.h"
 #include "metkit/mars/MarsRequest.h"
+
+
+/// Functions for performing extraction using eccodes directly, for testing and benchmarking purposes.
 
 namespace gribjump {
 


### PR DESCRIPTION
### Description
Explicitly set eccodes missing value to 9999 in tests rather than relying on the default value, which may be changed by eccodes

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 