### PR TITLE
Skip request parsing by default

### DIFF
--- a/src/gribjump/Config.cc
+++ b/src/gribjump/Config.cc
@@ -110,6 +110,12 @@ bool ConfigOptions::ignoreYearMonth() const {
     return value;
 }
 
+bool ConfigOptions::requestParsing() const {
+    static bool value = eckit::Resource<bool>("$GRIBJUMP_REQUEST_PARSING",
+                                              LibGribJump::instance().config().getBool("requestParsing", false));
+    return value;
+}
+
 bool ConfigOptions::allowMissing() const {
     static bool value = eckit::Resource<bool>("allowMissing;$GRIBJUMP_ALLOW_MISSING",
                                               LibGribJump::instance().config().getBool("allowMissing", false));

--- a/src/gribjump/Config.h
+++ b/src/gribjump/Config.h
@@ -88,6 +88,12 @@ public:
     /// If true, ignore year/month keys when date is present. Env: GRIBJUMP_IGNORE_YEARMONTH. Default: true.
     bool ignoreYearMonth() const;
 
+    /// If true, enable request parsing. Env: GRIBJUMP_REQUEST_PARSING (takes precedence).
+    /// YAML: requestParsing. Default: false.
+    /// Request parsing can be a bottleneck when we have many MARS requests, so this remains configurable
+    /// and may need to be revisited in the future.
+    bool requestParsing() const;
+
     /// If true, allow missing fields when listing. Env: GRIBJUMP_ALLOW_MISSING. Resource: allowMissing.
     /// YAML: allowMissing. Default: false.
     bool allowMissing() const;

--- a/src/gribjump/gribjump_c.cc
+++ b/src/gribjump/gribjump_c.cc
@@ -14,6 +14,7 @@
 #include <functional>
 #include <sstream>
 #include "eckit/runtime/Main.h"
+#include "gribjump/Config.h"
 #include "gribjump/ExtractionData.h"
 #include "gribjump/GribJump.h"
 #include "gribjump/api/ExtractionIterator.h"
@@ -172,9 +173,13 @@ gribjump_error_t gribjump_new_request(gribjump_extraction_request_t** request, c
 
         std::string gridhash_str = gridhash ? std::string(gridhash) : "";
 
-        metkit::mars::MarsRequest req = parseMarsRequest(reqstr);
+        if (ConfigOptions::instance().requestParsing()) {
+            metkit::mars::MarsRequest req = parseMarsRequest(reqstr);
+            *request                      = new gribjump_extraction_request_t(req.asString(), ranges, gridhash_str);
+            return;
+        }
 
-        *request = new gribjump_extraction_request_t(req.asString(), ranges, gridhash_str);
+        *request = new gribjump_extraction_request_t(reqstr, ranges, gridhash_str);
     });
 }
 


### PR DESCRIPTION
### Description

Unfortunately the metkit request parsing is prohibitively slow in our current polytope climate workflows. Disable it by default, and add an env var to re-enable it.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
