### PR TITLE
[pygribjump] bump cffi to 2+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ build-backend = "setuptools.build_meta"
 name = "pygribjump"
 description = "Python interface to GribJump"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dynamic = ["version"]
 authors = [
     { name = "ECMWF", email = "software.support@ecmwf.int" }
@@ -24,7 +24,7 @@ license = "Apache-2.0"
 license-files = ["LICENSE"]
 urls = { "Home" = "https://github.com/ecmwf/gribjump" }
 dependencies = [
-    "cffi~=1.17",
+    "cffi>=2.0,<3.0",
     "numpy>=1.26",
     "findlibs>=0.1.1",
     "packaging>=20.0",


### PR DESCRIPTION
this is to allow cryptography upgrade on fiab (and I guess elsewhere), as dependabot is mentioning a few criticals, and an upgrade requires cffi 2+

I've run wheel build action with this https://github.com/ecmwf/python-develop-bundle/actions/runs/25483811042/job/74774236621 -- the pygribjump wheel gets built ok, it just fails to upload to pypi because of running out of space there on the eckit