### PR TITLE
Feature/gj 66 roundrobin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-- No changes recorded yet.
+- Replace FIFO job queue with Round Robin queue, to prevent large requests starving small requests.
 
 ## [0.12.0] - 2026-05-07
 

--- a/docs/round-robin-scheduling.md
+++ b/docs/round-robin-scheduling.md
@@ -1,19 +1,15 @@
 # Round-Robin Work Scheduling
 
-This note documents the gribjump worker-thread scheduling system,
-covering the previous FIFO design, its limitations, and the new
-round-robin scheduler that replaces it.
+This note documents the gribjump worker-thread round-robin scheduling system.
 
 ## Overview
 
-Every public gribjump call (e.g. `Engine::extract`, `Engine::scan`) is
-served by a `TaskGroup`. The engine splits the request into many `Task`
-instances (one per file, typically), enqueues them on the shared
-`WorkQueue` singleton, and blocks in `TaskGroup::waitForTasks()` until
-every task has completed, errored, or been cancelled.
+Calls to gribjump's engine/schedulign system (e.g. `Engine::extract`, `Engine::scan`) are served by a single
+`TaskGroup`. The engine splits the request into many `Task` instances (one per file, typically), enqueues them
+on the shared `WorkQueue` singleton, and blocks in `TaskGroup::waitForTasks()` until every task has completed,
+errored, or been cancelled.
 
-A pool of worker threads (`ConfigOptions::numThreads()`) pops tasks
-from the `WorkQueue` and runs them.
+A pool of worker threads (`ConfigOptions::numThreads()`) pops tasks from the `WorkQueue` and runs them.
 
 ## Before: single FIFO queue
 
@@ -27,44 +23,36 @@ TaskGroup C.enqueueTask ──┘             (single FIFO)
 
 Properties:
 
-- **Strict FIFO**: tasks were dispatched strictly in the order in which
-  `WorkQueue::push(Task*)` was called.
-- **Bounded**: the queue had a hard cap (`ConfigOptions::queueSize()`,
-  default 1024) and producers blocked when it was full.
+- **Strict FIFO**: tasks were dispatched strictly in the order in which `WorkQueue::push(Task*)` was called.
+- **Bounded**: the queue had a hard cap (`ConfigOptions::queueSize()`, default 1024) and producers blocked
+  when it was full.
 
 ### The starvation problem
 
-Because every group shared one FIFO, a very large `TaskGroup` could
-completely block every later request. Concretely:
+Because every group shared one FIFO, a very large `TaskGroup` could completely block every later request.
+Concretely:
 
-1. Client A submits an extraction touching 10 000 files. `TaskGroup A`
-   pushes 10 000 tasks; the first 1 024 occupy the queue, the producer
-   then blocks waiting for slots.
-2. Client B submits a small extraction touching 5 files. `TaskGroup B`
-   tries to push, but the queue is full *and* the slots will be reused
-   by A's pending tasks as workers drain them.
-3. B's 5 tasks cannot enter the queue until enough of A's tasks have
-   been drained for A's producer to finish pushing, and even then B's
-   tasks sit behind whichever A tasks are queued ahead.
+1. Client A submits an extraction touching 10 000 files. `TaskGroup A` pushes 10 000 tasks; the first 1 024
+   occupy the queue, the producer then blocks waiting for slots.
+2. Client B submits a small extraction touching 5 files. `TaskGroup B` tries to push, but the queue is full
+   _and_ the slots will be reused by A's pending tasks as workers drain them.
+3. B's 5 tasks cannot enter the queue until enough of A's tasks have been drained for A's producer to finish
+   pushing, and even then B's tasks sit behind whichever A tasks are queued ahead.
 
-As a result, small requests waited for large requests to finish — a
-classic head-of-line blocking issue.
+As a result, small requests waited for large requests to finish — a classic head-of-line blocking issue.
 
-### Note on the old size cap
+## Round-robin per-group scheduling
 
-The old queue cap was not actually bounding any meaningful resource.
-By the time `push()` was called, the producer had already allocated
-every `ExtractionItem` and the entire `filemap` describing the
-request. A queued `Task*` is a small handle on top of that state, so
-capping the number of pending handles did not cap memory or I/O — it
-only added complexity and contributed to the starvation problem above.
-The cap (and the `GRIBJUMP_QUEUESIZE` / `gribjumpQueueSize` /
-`ConfigOptions::queueSize()` knob that exposed it) has been removed.
+All gribjump versions before 0.13.0 used a single FIFO `WorkQueue` for all task groups.
 
-## After: round-robin per-group scheduling
+```
+TaskGroup A.enqueueTask ──┐
+TaskGroup B.enqueueTask ──┼──►  [ A0 A1 A2 ... A999 B0 B1 ... ] ──► workers
+TaskGroup C.enqueueTask ──┘             (single FIFO)
+```
 
-The new `WorkQueue` keeps a separate FIFO per active `TaskGroup` and
-dispatches them in round-robin order:
+This meant that a very large job could completely block every later request. The new `WorkQueue` keeps a
+separate FIFO per active `TaskGroup` and dispatches them in round-robin order:
 
 ```
                  ┌─► [ A0 A1 A2 ... A999 ]
@@ -75,57 +63,47 @@ TaskGroup C.push ┤                            └─► A0, B0, C0,
                                                     A2, B2, A3, ...  ──► workers
 ```
 
+Which allows small requests to be handled while large requests are still in prgoress.
+
 ### Data structures
 
-- `std::unordered_map<TaskGroup*, std::deque<Task*>> groupQueues_` —
-  the per-group FIFO of pending tasks. A group is present only while
-  it has at least one queued task.
-- `std::list<TaskGroup*> rrOrder_` — the round-robin rotation. Each
-  group appears at most once. The front is served next.
-- A single mutex `mtx_` and condition variable `cv_` coordinate
-  producers, consumers, and shutdown.
+- `std::unordered_map<TaskGroup*, std::deque<Task*>> groupQueues_` — the per-group FIFO of pending tasks. A
+  group is present only while it has at least one queued task.
+- `std::list<TaskGroup*> rrOrder_` — the round-robin rotation. Each group appears at most once. The front is
+  served next.
+- A single mutex `mtx_` and condition variable `cv_` coordinate producers, consumers, and shutdown.
 
-The queue is **unbounded** — `push` never blocks. See "Why no size
-cap" above.
-
-### Push (`WorkQueue::push(TaskGroup*, Task*)`)
+### Push (`WorkQueue::push(TaskGroup*, Task*)`)d
 
 1. Lock `mtx_`.
-2. If the group is not yet in `groupQueues_`, insert an empty deque
-   for it and append the group to the back of `rrOrder_`.
+2. If the group is not yet in `groupQueues_`, insert an empty deque for it and append the group to the back of
+   `rrOrder_`.
 3. Append the task to the group's deque.
 4. Unlock; signal `cv_`.
 
-`push` is non-blocking and constant-time. A newcomer is always
-admitted immediately into the rotation, so no producer can starve
-another.
+`push` is non-blocking and constant-time. A newcomer is always admitted immediately into the rotation, so no
+producer can starve another.
 
 ### Pop (worker thread)
 
-1. Lock `mtx_`. Wait on `cv_` until `rrOrder_` is non-empty or the
-   queue is closed.
-2. Take the group `g` at the front of `rrOrder_`; pop one task from
-   `groupQueues_[g]`.
-3. If `g`'s queue is now empty, erase `g` from `groupQueues_`;
-   otherwise re-append `g` to the back of `rrOrder_`. This is the
-   round-robin rotation.
+1. Lock `mtx_`. Wait on `cv_` until `rrOrder_` is non-empty or the queue is closed.
+2. Take the group `g` at the front of `rrOrder_`; pop one task from `groupQueues_[g]`.
+3. If `g`'s queue is now empty, erase `g` from `groupQueues_`; otherwise re-append `g` to the back of
+   `rrOrder_`. This is the round-robin rotation.
 4. Unlock; execute the task outside the mutex.
 
-Each task served = exactly one rotation step, so with `k` active
-groups the worst-case latency for any one group is `k − 1` other
-tasks ahead.
+Each task served = exactly one rotation step, so with `k` active groups the worst-case latency for any one
+group is `k − 1` other tasks ahead.
 
 ### Shutdown
 
-Destruction sets `closed_ = true`, notifies the condition variable,
-and joins the worker threads. Workers continue draining tasks until
-`rrOrder_` is empty, after which they exit. `push` after close is a
-programming error and asserts.
+Destruction sets `closed_ = true`, notifies the condition variable, and joins the worker threads. Workers
+continue draining tasks until `rrOrder_` is empty, after which they exit. `push` after close is a programming
+error and asserts.
 
 ## API change
 
-`WorkQueue::push` now takes the owning `TaskGroup*` as well as the
-`Task*`:
+`WorkQueue::push` now takes the owning `TaskGroup*` as well as the `Task*`:
 
 ```cpp
 // before
@@ -135,13 +113,12 @@ WorkQueue::instance().push(task);
 WorkQueue::instance().push(this, task);   // called from TaskGroup::enqueueTask
 ```
 
-`TaskGroup::enqueueTask` is the only caller of `WorkQueue::push`, so
-the change is fully internal.
+`TaskGroup::enqueueTask` is the only caller of `WorkQueue::push`, so the change is fully internal.
 
 ## Properties summary
 
 | Property                              | Before (FIFO)           | After (round-robin)              |
-|---------------------------------------|-------------------------|----------------------------------|
+| ------------------------------------- | ----------------------- | -------------------------------- |
 | Dispatch order                        | Strict global FIFO      | Round-robin across active groups |
 | Head-of-line blocking between groups  | Yes                     | No                               |
 | Worst-case wait for next group's task | All earlier tasks       | `(k − 1)` tasks (`k` groups)     |
@@ -153,16 +130,12 @@ the change is fully internal.
 
 ## Known limitations / future work
 
-- **No priority / weighting.** All groups are treated equally. Adding
-  weighted round-robin (e.g. proportional to client quota) is a
-  straightforward extension of the `rrOrder_` rotation.
-- **Group identity is the `TaskGroup*` pointer.** This is safe because
-  `TaskGroup::waitForTasks` guarantees the group outlives every one
-  of its tasks in the queue, but the scheduler does not expose a
-  stable external client/session identifier — distinct requests from
-  the same client are still distinct groups.
-- **No flow control on producers.** Removing the cap means a runaway
-  producer could grow `groupQueues_` without bound. In practice this
-  is gated by upstream limits (request size, FDB list latency), but
-  if a future workload changes that assumption an explicit per-group
-  or per-client cap would be the right place to add it back.
+- **No priority / weighting.** All groups are treated equally. Adding weighted round-robin (e.g. proportional
+  to client quota) is a straightforward extension of the `rrOrder_` rotation.
+- **Group identity is the `TaskGroup*` pointer.** This is safe because `TaskGroup::waitForTasks` guarantees
+  the group outlives every one of its tasks in the queue, but the scheduler does not expose a stable external
+  client/session identifier — distinct requests from the same client are still distinct groups.
+- **No flow control on producers.** Removing the cap means a runaway producer could grow `groupQueues_`
+  without bound. In practice this is gated by upstream limits (request size, FDB list latency), but if a
+  future workload changes that assumption an explicit per-group or per-client cap would be the right place to
+  add it back.

--- a/docs/round-robin-scheduling.md
+++ b/docs/round-robin-scheduling.md
@@ -12,10 +12,8 @@ instances (one per file, typically), enqueues them on the shared
 `WorkQueue` singleton, and blocks in `TaskGroup::waitForTasks()` until
 every task has completed, errored, or been cancelled.
 
-A pool of worker threads (`ConfigOptions::numThreads()`) pops tasks from
-the `WorkQueue` and runs them. The queue is bounded
-(`ConfigOptions::queueSize()`, default 1024) so producers experience
-backpressure when the system is saturated.
+A pool of worker threads (`ConfigOptions::numThreads()`) pops tasks
+from the `WorkQueue` and runs them.
 
 ## Before: single FIFO queue
 
@@ -31,7 +29,8 @@ Properties:
 
 - **Strict FIFO**: tasks were dispatched strictly in the order in which
   `WorkQueue::push(Task*)` was called.
-- **Bounded**: producers blocked when the global queue was full.
+- **Bounded**: the queue had a hard cap (`ConfigOptions::queueSize()`,
+  default 1024) and producers blocked when it was full.
 
 ### The starvation problem
 
@@ -51,6 +50,17 @@ completely block every later request. Concretely:
 As a result, small requests waited for large requests to finish — a
 classic head-of-line blocking issue.
 
+### Note on the old size cap
+
+The old queue cap was not actually bounding any meaningful resource.
+By the time `push()` was called, the producer had already allocated
+every `ExtractionItem` and the entire `filemap` describing the
+request. A queued `Task*` is a small handle on top of that state, so
+capping the number of pending handles did not cap memory or I/O — it
+only added complexity and contributed to the starvation problem above.
+The cap (and the `GRIBJUMP_QUEUESIZE` / `gribjumpQueueSize` /
+`ConfigOptions::queueSize()` knob that exposed it) has been removed.
+
 ## After: round-robin per-group scheduling
 
 The new `WorkQueue` keeps a separate FIFO per active `TaskGroup` and
@@ -68,50 +78,49 @@ TaskGroup C.push ┤                            └─► A0, B0, C0,
 ### Data structures
 
 - `std::unordered_map<TaskGroup*, std::deque<Task*>> groupQueues_` —
-  the per-group FIFO of pending tasks. A group is present only while it
-  has at least one queued task.
+  the per-group FIFO of pending tasks. A group is present only while
+  it has at least one queued task.
 - `std::list<TaskGroup*> rrOrder_` — the round-robin rotation. Each
   group appears at most once. The front is served next.
-- `size_t totalTasks_` and `size_t maxSize_` — preserve the existing
-  global backpressure cap.
+- A single mutex `mtx_` and condition variable `cv_` coordinate
+  producers, consumers, and shutdown.
+
+The queue is **unbounded** — `push` never blocks. See "Why no size
+cap" above.
 
 ### Push (`WorkQueue::push(TaskGroup*, Task*)`)
 
-1. If the group is **already** in `groupQueues_`, the producer waits on
-   `cvPush_` while `totalTasks_ >= maxSize_` (standard backpressure),
-   then appends the task to the group's deque.
-2. If the group is **new** (not currently in the rotation), the push is
-   admitted immediately — bypassing the global cap for the *first*
-   task. The group is inserted in `groupQueues_` and pushed to the back
-   of `rrOrder_`.
-3. `totalTasks_` is incremented and `cvPop_` is signalled.
+1. Lock `mtx_`.
+2. If the group is not yet in `groupQueues_`, insert an empty deque
+   for it and append the group to the back of `rrOrder_`.
+3. Append the task to the group's deque.
+4. Unlock; signal `cv_`.
 
-**Admission bypass** is a deliberate fairness guarantee: a saturating
-producer cannot prevent a newcomer from entering the rotation. Once a
-group is in the rotation, its tasks are served alongside everyone
-else's.
+`push` is non-blocking and constant-time. A newcomer is always
+admitted immediately into the rotation, so no producer can starve
+another.
 
 ### Pop (worker thread)
 
-1. Wait on `cvPop_` until `rrOrder_` is non-empty or the queue is
-   closed.
+1. Lock `mtx_`. Wait on `cv_` until `rrOrder_` is non-empty or the
+   queue is closed.
 2. Take the group `g` at the front of `rrOrder_`; pop one task from
    `groupQueues_[g]`.
 3. If `g`'s queue is now empty, erase `g` from `groupQueues_`;
    otherwise re-append `g` to the back of `rrOrder_`. This is the
    round-robin rotation.
-4. Signal `cvPush_` so any blocked producers can re-check the cap.
-5. Execute the task outside the mutex.
+4. Unlock; execute the task outside the mutex.
 
-Each task served = exactly one rotation step, so with `k` active groups
-the worst-case latency for any one group is `k - 1` other tasks ahead.
+Each task served = exactly one rotation step, so with `k` active
+groups the worst-case latency for any one group is `k − 1` other
+tasks ahead.
 
 ### Shutdown
 
-Destruction sets `closed_ = true`, notifies both condition variables,
+Destruction sets `closed_ = true`, notifies the condition variable,
 and joins the worker threads. Workers continue draining tasks until
-`rrOrder_` is empty, after which they exit. `push` after close throws
-`eckit::SeriousBug` (this only occurs at program teardown).
+`rrOrder_` is empty, after which they exit. `push` after close is a
+programming error and asserts.
 
 ## API change
 
@@ -136,24 +145,24 @@ the change is fully internal.
 | Dispatch order                        | Strict global FIFO      | Round-robin across active groups |
 | Head-of-line blocking between groups  | Yes                     | No                               |
 | Worst-case wait for next group's task | All earlier tasks       | `(k − 1)` tasks (`k` groups)     |
-| Global capacity cap                   | `queueSize` (hard)      | `queueSize` (soft for new groups)|
-| New group admission under saturation  | Blocked behind producer | Always admitted (first task)     |
+| Producer backpressure                 | Blocks at `queueSize`   | None (push is non-blocking)      |
+| `queueSize` / `GRIBJUMP_QUEUESIZE`    | Honoured (default 1024) | Removed                          |
 | Per-group ordering                    | FIFO                    | FIFO (unchanged)                 |
 | Push API                              | `push(Task*)`           | `push(TaskGroup*, Task*)`        |
 | Cancellation behaviour                | Unchanged               | Unchanged                        |
 
 ## Known limitations / future work
 
-- **Pre-admission fairness across many simultaneous producers.** Once
-  the global cap is hit, multiple producers from already-admitted
-  groups compete for slots via `cvPush_.notify_all()`; the OS thread
-  scheduler decides who wins. Per-group fair admission queues would
-  require a more elaborate design and are not implemented.
 - **No priority / weighting.** All groups are treated equally. Adding
   weighted round-robin (e.g. proportional to client quota) is a
   straightforward extension of the `rrOrder_` rotation.
 - **Group identity is the `TaskGroup*` pointer.** This is safe because
-  `TaskGroup::waitForTasks` guarantees the group outlives every one of
-  its tasks in the queue, but the scheduler does not expose a stable
-  external client/session identifier — distinct requests from the same
-  client are still distinct groups.
+  `TaskGroup::waitForTasks` guarantees the group outlives every one
+  of its tasks in the queue, but the scheduler does not expose a
+  stable external client/session identifier — distinct requests from
+  the same client are still distinct groups.
+- **No flow control on producers.** Removing the cap means a runaway
+  producer could grow `groupQueues_` without bound. In practice this
+  is gated by upstream limits (request size, FDB list latency), but
+  if a future workload changes that assumption an explicit per-group
+  or per-client cap would be the right place to add it back.

--- a/docs/round-robin-scheduling.md
+++ b/docs/round-robin-scheduling.md
@@ -1,0 +1,159 @@
+# Round-Robin Work Scheduling
+
+This note documents the gribjump worker-thread scheduling system,
+covering the previous FIFO design, its limitations, and the new
+round-robin scheduler that replaces it.
+
+## Overview
+
+Every public gribjump call (e.g. `Engine::extract`, `Engine::scan`) is
+served by a `TaskGroup`. The engine splits the request into many `Task`
+instances (one per file, typically), enqueues them on the shared
+`WorkQueue` singleton, and blocks in `TaskGroup::waitForTasks()` until
+every task has completed, errored, or been cancelled.
+
+A pool of worker threads (`ConfigOptions::numThreads()`) pops tasks from
+the `WorkQueue` and runs them. The queue is bounded
+(`ConfigOptions::queueSize()`, default 1024) so producers experience
+backpressure when the system is saturated.
+
+## Before: single FIFO queue
+
+The old `WorkQueue` wrapped a single `eckit::Queue<WorkItem>`:
+
+```
+TaskGroup A.enqueueTask ──┐
+TaskGroup B.enqueueTask ──┼──►  [ A0 A1 A2 ... A999 B0 B1 ... ] ──► workers
+TaskGroup C.enqueueTask ──┘             (single FIFO)
+```
+
+Properties:
+
+- **Strict FIFO**: tasks were dispatched strictly in the order in which
+  `WorkQueue::push(Task*)` was called.
+- **Bounded**: producers blocked when the global queue was full.
+
+### The starvation problem
+
+Because every group shared one FIFO, a very large `TaskGroup` could
+completely block every later request. Concretely:
+
+1. Client A submits an extraction touching 10 000 files. `TaskGroup A`
+   pushes 10 000 tasks; the first 1 024 occupy the queue, the producer
+   then blocks waiting for slots.
+2. Client B submits a small extraction touching 5 files. `TaskGroup B`
+   tries to push, but the queue is full *and* the slots will be reused
+   by A's pending tasks as workers drain them.
+3. B's 5 tasks cannot enter the queue until enough of A's tasks have
+   been drained for A's producer to finish pushing, and even then B's
+   tasks sit behind whichever A tasks are queued ahead.
+
+As a result, small requests waited for large requests to finish — a
+classic head-of-line blocking issue.
+
+## After: round-robin per-group scheduling
+
+The new `WorkQueue` keeps a separate FIFO per active `TaskGroup` and
+dispatches them in round-robin order:
+
+```
+                 ┌─► [ A0 A1 A2 ... A999 ]
+TaskGroup A.push ┤
+TaskGroup B.push ┼─► [ B0 B1 B2 B3 B4   ]   round-robin
+TaskGroup C.push ┤                            └─► A0, B0, C0,
+                 └─► [ C0 C1            ]          A1, B1, C1,
+                                                    A2, B2, A3, ...  ──► workers
+```
+
+### Data structures
+
+- `std::unordered_map<TaskGroup*, std::deque<Task*>> groupQueues_` —
+  the per-group FIFO of pending tasks. A group is present only while it
+  has at least one queued task.
+- `std::list<TaskGroup*> rrOrder_` — the round-robin rotation. Each
+  group appears at most once. The front is served next.
+- `size_t totalTasks_` and `size_t maxSize_` — preserve the existing
+  global backpressure cap.
+
+### Push (`WorkQueue::push(TaskGroup*, Task*)`)
+
+1. If the group is **already** in `groupQueues_`, the producer waits on
+   `cvPush_` while `totalTasks_ >= maxSize_` (standard backpressure),
+   then appends the task to the group's deque.
+2. If the group is **new** (not currently in the rotation), the push is
+   admitted immediately — bypassing the global cap for the *first*
+   task. The group is inserted in `groupQueues_` and pushed to the back
+   of `rrOrder_`.
+3. `totalTasks_` is incremented and `cvPop_` is signalled.
+
+**Admission bypass** is a deliberate fairness guarantee: a saturating
+producer cannot prevent a newcomer from entering the rotation. Once a
+group is in the rotation, its tasks are served alongside everyone
+else's.
+
+### Pop (worker thread)
+
+1. Wait on `cvPop_` until `rrOrder_` is non-empty or the queue is
+   closed.
+2. Take the group `g` at the front of `rrOrder_`; pop one task from
+   `groupQueues_[g]`.
+3. If `g`'s queue is now empty, erase `g` from `groupQueues_`;
+   otherwise re-append `g` to the back of `rrOrder_`. This is the
+   round-robin rotation.
+4. Signal `cvPush_` so any blocked producers can re-check the cap.
+5. Execute the task outside the mutex.
+
+Each task served = exactly one rotation step, so with `k` active groups
+the worst-case latency for any one group is `k - 1` other tasks ahead.
+
+### Shutdown
+
+Destruction sets `closed_ = true`, notifies both condition variables,
+and joins the worker threads. Workers continue draining tasks until
+`rrOrder_` is empty, after which they exit. `push` after close throws
+`eckit::SeriousBug` (this only occurs at program teardown).
+
+## API change
+
+`WorkQueue::push` now takes the owning `TaskGroup*` as well as the
+`Task*`:
+
+```cpp
+// before
+WorkQueue::instance().push(task);
+
+// after
+WorkQueue::instance().push(this, task);   // called from TaskGroup::enqueueTask
+```
+
+`TaskGroup::enqueueTask` is the only caller of `WorkQueue::push`, so
+the change is fully internal.
+
+## Properties summary
+
+| Property                              | Before (FIFO)           | After (round-robin)              |
+|---------------------------------------|-------------------------|----------------------------------|
+| Dispatch order                        | Strict global FIFO      | Round-robin across active groups |
+| Head-of-line blocking between groups  | Yes                     | No                               |
+| Worst-case wait for next group's task | All earlier tasks       | `(k − 1)` tasks (`k` groups)     |
+| Global capacity cap                   | `queueSize` (hard)      | `queueSize` (soft for new groups)|
+| New group admission under saturation  | Blocked behind producer | Always admitted (first task)     |
+| Per-group ordering                    | FIFO                    | FIFO (unchanged)                 |
+| Push API                              | `push(Task*)`           | `push(TaskGroup*, Task*)`        |
+| Cancellation behaviour                | Unchanged               | Unchanged                        |
+
+## Known limitations / future work
+
+- **Pre-admission fairness across many simultaneous producers.** Once
+  the global cap is hit, multiple producers from already-admitted
+  groups compete for slots via `cvPush_.notify_all()`; the OS thread
+  scheduler decides who wins. Per-group fair admission queues would
+  require a more elaborate design and are not implemented.
+- **No priority / weighting.** All groups are treated equally. Adding
+  weighted round-robin (e.g. proportional to client quota) is a
+  straightforward extension of the `rrOrder_` rotation.
+- **Group identity is the `TaskGroup*` pointer.** This is safe because
+  `TaskGroup::waitForTasks` guarantees the group outlives every one of
+  its tasks in the queue, but the scheduler does not expose a stable
+  external client/session identifier — distinct requests from the same
+  client are still distinct groups.

--- a/docs/round-robin-scheduling.md
+++ b/docs/round-robin-scheduling.md
@@ -101,41 +101,16 @@ Destruction sets `closed_ = true`, notifies the condition variable, and joins th
 continue draining tasks until `rrOrder_` is empty, after which they exit. `push` after close is a programming
 error and asserts.
 
-## API change
+### Lifetime of the `TaskGroup*`
 
-`WorkQueue::push` now takes the owning `TaskGroup*` as well as the `Task*`:
+`TaskGroup::waitForTasks()` blocks until every task has notified completion, and tasks notify _after_ being
+popped from the `WorkQueue` (popping removes the group's entry from `groupQueues_`/`rrOrder_` under the
+queue's mutex, before the task runs). Therefore, by the time `waitForTasks()` returns, the `WorkQueue` no
+longer holds the group's pointer in any data structure, and the group is safe to destroy. This is the only
+lifetime requirement the round-robin scheduler imposes.
 
-```cpp
-// before
-WorkQueue::instance().push(task);
-
-// after
-WorkQueue::instance().push(this, task);   // called from TaskGroup::enqueueTask
-```
-
-`TaskGroup::enqueueTask` is the only caller of `WorkQueue::push`, so the change is fully internal.
-
-## Properties summary
-
-| Property                              | Before (FIFO)           | After (round-robin)              |
-| ------------------------------------- | ----------------------- | -------------------------------- |
-| Dispatch order                        | Strict global FIFO      | Round-robin across active groups |
-| Head-of-line blocking between groups  | Yes                     | No                               |
-| Worst-case wait for next group's task | All earlier tasks       | `(k − 1)` tasks (`k` groups)     |
-| Producer backpressure                 | Blocks at `queueSize`   | None (push is non-blocking)      |
-| `queueSize` / `GRIBJUMP_QUEUESIZE`    | Honoured (default 1024) | Removed                          |
-| Per-group ordering                    | FIFO                    | FIFO (unchanged)                 |
-| Push API                              | `push(Task*)`           | `push(TaskGroup*, Task*)`        |
-| Cancellation behaviour                | Unchanged               | Unchanged                        |
-
-## Known limitations / future work
+## Known limitations
 
 - **No priority / weighting.** All groups are treated equally. Adding weighted round-robin (e.g. proportional
   to client quota) is a straightforward extension of the `rrOrder_` rotation.
-- **Group identity is the `TaskGroup*` pointer.** This is safe because `TaskGroup::waitForTasks` guarantees
-  the group outlives every one of its tasks in the queue, but the scheduler does not expose a stable external
-  client/session identifier — distinct requests from the same client are still distinct groups.
-- **No flow control on producers.** Removing the cap means a runaway producer could grow `groupQueues_`
-  without bound. In practice this is gated by upstream limits (request size, FDB list latency), but if a
-  future workload changes that assumption an explicit per-group or per-client cap would be the right place to
-  add it back.
+- **No flow control on producers.** A runaway producer could grow `groupQueues_` without bound.

--- a/src/gribjump/Config.cc
+++ b/src/gribjump/Config.cc
@@ -94,11 +94,6 @@ size_t ConfigOptions::numThreads() const {
     return value;
 }
 
-size_t ConfigOptions::queueSize() const {
-    static size_t value = eckit::Resource<size_t>("$GRIBJUMP_QUEUESIZE;gribjumpQueueSize", 1024);
-    return value;
-}
-
 bool ConfigOptions::ignoreGrid() const {
     static bool value = eckit::Resource<bool>("$GRIBJUMP_IGNORE_GRID",
                                               LibGribJump::instance().config().getBool("ignoreGridHash", false));

--- a/src/gribjump/Config.cc
+++ b/src/gribjump/Config.cc
@@ -8,7 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 
 #include "gribjump/Config.h"
 #include "eckit/config/Resource.h"

--- a/src/gribjump/Config.h
+++ b/src/gribjump/Config.h
@@ -76,9 +76,6 @@ public:
     /// Number of worker threads. Env: GRIBJUMP_THREADS. Resource: gribjumpThreads. YAML: threads. Default: 1.
     size_t numThreads() const;
 
-    /// Work queue size. Env: GRIBJUMP_QUEUESIZE. Resource: gribjumpQueueSize. Default: 1024.
-    size_t queueSize() const;
-
     // -- Extraction options --
 
     /// If true, ignore grid hash checks during extraction. Env: GRIBJUMP_IGNORE_GRID. YAML: ignoreGridHash.

--- a/src/gribjump/Config.h
+++ b/src/gribjump/Config.h
@@ -8,7 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 
 #pragma once
 

--- a/src/gribjump/Engine.cc
+++ b/src/gribjump/Engine.cc
@@ -8,7 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 
 #include "eckit/utils/StringTools.h"
 

--- a/src/gribjump/Engine.h
+++ b/src/gribjump/Engine.h
@@ -8,7 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 
 #pragma once
 

--- a/src/gribjump/ExtractionData.cc
+++ b/src/gribjump/ExtractionData.cc
@@ -8,7 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 
 #include "gribjump/ExtractionData.h"
 #include "eckit/io/Buffer.h"

--- a/src/gribjump/ExtractionData.h
+++ b/src/gribjump/ExtractionData.h
@@ -8,7 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 /// @author Tiago Quintino
 
 #pragma once

--- a/src/gribjump/ExtractionItem.cc
+++ b/src/gribjump/ExtractionItem.cc
@@ -8,7 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 
 #include "gribjump/ExtractionItem.h"
 

--- a/src/gribjump/ExtractionItem.h
+++ b/src/gribjump/ExtractionItem.h
@@ -8,7 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 
 #pragma once
 

--- a/src/gribjump/Forwarder.cc
+++ b/src/gribjump/Forwarder.cc
@@ -8,7 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 
 #include "gribjump/Forwarder.h"
 #include <atomic>

--- a/src/gribjump/Forwarder.h
+++ b/src/gribjump/Forwarder.h
@@ -8,7 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 #include "eckit/net/Endpoint.h"
 #include "gribjump/Engine.h"
 #include "gribjump/Task.h"

--- a/src/gribjump/GribJump.cc
+++ b/src/gribjump/GribJump.cc
@@ -8,7 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 /// @author Tiago Quintino
 
 #include "eckit/log/Timer.h"

--- a/src/gribjump/GribJump.h
+++ b/src/gribjump/GribJump.h
@@ -8,7 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 /// @author Tiago Quintino
 
 #pragma once

--- a/src/gribjump/GribJumpBase.h
+++ b/src/gribjump/GribJumpBase.h
@@ -8,7 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 /// @author Tiago Quintino
 
 #pragma once

--- a/src/gribjump/GribJumpException.h
+++ b/src/gribjump/GribJumpException.h
@@ -8,7 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 
 #pragma once
 

--- a/src/gribjump/LibGribJump.cc
+++ b/src/gribjump/LibGribJump.cc
@@ -8,7 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 
 #include "gribjump/LibGribJump.h"
 

--- a/src/gribjump/LibGribJump.h
+++ b/src/gribjump/LibGribJump.h
@@ -8,7 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 /// @author Tiago Quintino
 /// @date   Dec 2023
 

--- a/src/gribjump/Lister.cc
+++ b/src/gribjump/Lister.cc
@@ -8,7 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 
 #include "eckit/log/Log.h"
 

--- a/src/gribjump/Lister.h
+++ b/src/gribjump/Lister.h
@@ -8,7 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 
 #pragma once
 

--- a/src/gribjump/LocalGribJump.cc
+++ b/src/gribjump/LocalGribJump.cc
@@ -8,7 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 /// @author Tiago Quintino
 
 #include <chrono>

--- a/src/gribjump/LocalGribJump.h
+++ b/src/gribjump/LocalGribJump.h
@@ -8,7 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 /// @author Tiago Quintino
 
 #pragma once

--- a/src/gribjump/LogRouter.cc
+++ b/src/gribjump/LogRouter.cc
@@ -8,7 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 
 #include "gribjump/LogRouter.h"
 #include "gribjump/LibGribJump.h"

--- a/src/gribjump/LogRouter.h
+++ b/src/gribjump/LogRouter.h
@@ -8,7 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 
 #pragma once
 

--- a/src/gribjump/Metrics.cc
+++ b/src/gribjump/Metrics.cc
@@ -8,7 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 
 #include "gribjump/Metrics.h"
 #include "eckit/log/Log.h"

--- a/src/gribjump/Metrics.h
+++ b/src/gribjump/Metrics.h
@@ -8,7 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 
 #pragma once
 

--- a/src/gribjump/Stats.cc
+++ b/src/gribjump/Stats.cc
@@ -8,7 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 
 #include "gribjump/Stats.h"
 

--- a/src/gribjump/Stats.h
+++ b/src/gribjump/Stats.h
@@ -8,7 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 
 #pragma once
 

--- a/src/gribjump/Task.cc
+++ b/src/gribjump/Task.cc
@@ -127,7 +127,7 @@ void TaskGroup::enqueueTask(Task* task) {
         tasks_.push_back(std::unique_ptr<Task>(task));  // TaskGroup takes ownership of its tasks
     }
 
-    WorkQueue::instance().push(task);  /// @note Can block, so release the lock first
+    WorkQueue::instance().push(this, task);  /// @note Can block, so release the lock first
 
     LOG_DEBUG_LIB(LibGribJump) << "Queued task " << tasks_.size() << std::endl;
 }

--- a/src/gribjump/Task.cc
+++ b/src/gribjump/Task.cc
@@ -127,7 +127,7 @@ void TaskGroup::enqueueTask(Task* task) {
         tasks_.push_back(std::unique_ptr<Task>(task));  // TaskGroup takes ownership of its tasks
     }
 
-    WorkQueue::instance().push(this, task);  /// @note Can block, so release the lock first
+    WorkQueue::instance().push(this, task);  // release TaskGroup lock before taking WorkQueue lock
 
     LOG_DEBUG_LIB(LibGribJump) << "Queued task " << tasks_.size() << std::endl;
 }

--- a/src/gribjump/URIHelper.h
+++ b/src/gribjump/URIHelper.h
@@ -8,7 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 #include "eckit/exception/Exceptions.h"
 #include "eckit/filesystem/URI.h"
 #pragma once

--- a/src/gribjump/api/ExtractionIterator.h
+++ b/src/gribjump/api/ExtractionIterator.h
@@ -8,7 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 
 #pragma once
 

--- a/src/gribjump/gribjump_c.cc
+++ b/src/gribjump/gribjump_c.cc
@@ -8,7 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 
 #include "gribjump/gribjump_c.h"
 #include <functional>

--- a/src/gribjump/gribjump_c.h
+++ b/src/gribjump/gribjump_c.h
@@ -8,7 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 
 #pragma once
 #include <stddef.h>

--- a/src/gribjump/info/CcsdsInfo.cc
+++ b/src/gribjump/info/CcsdsInfo.cc
@@ -8,7 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 
 #include "eckit/io/DataHandle.h"
 

--- a/src/gribjump/info/CcsdsInfo.h
+++ b/src/gribjump/info/CcsdsInfo.h
@@ -8,7 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 
 #pragma once
 

--- a/src/gribjump/info/InfoAggregator.cc
+++ b/src/gribjump/info/InfoAggregator.cc
@@ -8,7 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 #include "eckit/io/DataHandle.h"
 
 #include "fdb5/database/FieldLocation.h"

--- a/src/gribjump/info/InfoAggregator.h
+++ b/src/gribjump/info/InfoAggregator.h
@@ -8,7 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 
 #pragma once
 

--- a/src/gribjump/info/InfoCache.cc
+++ b/src/gribjump/info/InfoCache.cc
@@ -8,7 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 /// @author Tiago Quintino
 
 

--- a/src/gribjump/info/InfoCache.h
+++ b/src/gribjump/info/InfoCache.h
@@ -8,7 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 /// @author Tiago Quintino
 
 #pragma once

--- a/src/gribjump/info/InfoExtractor.cc
+++ b/src/gribjump/info/InfoExtractor.cc
@@ -8,7 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 
 #include "gribjump/info/InfoExtractor.h"
 

--- a/src/gribjump/info/InfoExtractor.h
+++ b/src/gribjump/info/InfoExtractor.h
@@ -8,7 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 
 #pragma once
 

--- a/src/gribjump/info/InfoFactory.cc
+++ b/src/gribjump/info/InfoFactory.cc
@@ -8,7 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 
 
 #include "eckit/io/DataHandle.h"

--- a/src/gribjump/info/InfoFactory.h
+++ b/src/gribjump/info/InfoFactory.h
@@ -8,7 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 
 #pragma once
 

--- a/src/gribjump/info/JumpInfo.cc
+++ b/src/gribjump/info/JumpInfo.cc
@@ -8,7 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 
 
 #include <sstream>

--- a/src/gribjump/info/JumpInfo.h
+++ b/src/gribjump/info/JumpInfo.h
@@ -8,7 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 
 #pragma once
 

--- a/src/gribjump/info/LRUCache.h
+++ b/src/gribjump/info/LRUCache.h
@@ -8,7 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 
 #pragma once
 

--- a/src/gribjump/info/SimpleInfo.cc
+++ b/src/gribjump/info/SimpleInfo.cc
@@ -8,7 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 
 #include "gribjump/info/SimpleInfo.h"
 #include "gribjump/info/InfoFactory.h"

--- a/src/gribjump/info/SimpleInfo.h
+++ b/src/gribjump/info/SimpleInfo.h
@@ -8,7 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 
 #pragma once
 

--- a/src/gribjump/info/UnsupportedInfo.cc
+++ b/src/gribjump/info/UnsupportedInfo.cc
@@ -8,7 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 
 #include "gribjump/info/UnsupportedInfo.h"
 #include "gribjump/info/InfoFactory.h"

--- a/src/gribjump/info/UnsupportedInfo.h
+++ b/src/gribjump/info/UnsupportedInfo.h
@@ -8,7 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 
 #pragma once
 

--- a/src/gribjump/jumper/CcsdsJumper.cc
+++ b/src/gribjump/jumper/CcsdsJumper.cc
@@ -8,7 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 
 #include "gribjump/jumper/CcsdsJumper.h"
 #include "gribjump/GribJumpDataAccessor.h"

--- a/src/gribjump/jumper/CcsdsJumper.h
+++ b/src/gribjump/jumper/CcsdsJumper.h
@@ -8,7 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 
 #pragma once
 

--- a/src/gribjump/jumper/Jumper.cc
+++ b/src/gribjump/jumper/Jumper.cc
@@ -8,7 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 
 #include "eckit/exception/Exceptions.h"
 #include "eckit/io/DataHandle.h"

--- a/src/gribjump/jumper/Jumper.h
+++ b/src/gribjump/jumper/Jumper.h
@@ -8,7 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 
 #pragma once
 

--- a/src/gribjump/jumper/JumperFactory.cc
+++ b/src/gribjump/jumper/JumperFactory.cc
@@ -8,7 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 
 #include "gribjump/jumper/JumperFactory.h"
 

--- a/src/gribjump/jumper/JumperFactory.h
+++ b/src/gribjump/jumper/JumperFactory.h
@@ -8,7 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 
 #pragma once
 

--- a/src/gribjump/jumper/SimpleJumper.cc
+++ b/src/gribjump/jumper/SimpleJumper.cc
@@ -8,7 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 
 #include "gribjump/jumper/SimpleJumper.h"
 #include "gribjump/GribJumpDataAccessor.h"

--- a/src/gribjump/jumper/SimpleJumper.h
+++ b/src/gribjump/jumper/SimpleJumper.h
@@ -8,7 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 
 #pragma once
 

--- a/src/gribjump/remote/GribJumpServer.h
+++ b/src/gribjump/remote/GribJumpServer.h
@@ -8,7 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 
 #pragma once
 

--- a/src/gribjump/remote/GribJumpService.h
+++ b/src/gribjump/remote/GribJumpService.h
@@ -8,7 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 
 #pragma once
 

--- a/src/gribjump/remote/GribJumpUser.cc
+++ b/src/gribjump/remote/GribJumpUser.cc
@@ -8,7 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 /// @author Tiago Quintino
 
 #include "eckit/log/Timer.h"

--- a/src/gribjump/remote/GribJumpUser.h
+++ b/src/gribjump/remote/GribJumpUser.h
@@ -8,7 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 
 #pragma once
 

--- a/src/gribjump/remote/RemoteGribJump.cc
+++ b/src/gribjump/remote/RemoteGribJump.cc
@@ -8,7 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 #include <algorithm>
 
 #include "eckit/log/Log.h"

--- a/src/gribjump/remote/RemoteGribJump.h
+++ b/src/gribjump/remote/RemoteGribJump.h
@@ -8,7 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 
 #pragma once
 

--- a/src/gribjump/remote/Request.cc
+++ b/src/gribjump/remote/Request.cc
@@ -8,7 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 /// @author Tiago Quintino
 
 #include "gribjump/remote/Request.h"

--- a/src/gribjump/remote/Request.h
+++ b/src/gribjump/remote/Request.h
@@ -8,7 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 /// @author Tiago Quintino
 
 #pragma once

--- a/src/gribjump/remote/WorkItem.cc
+++ b/src/gribjump/remote/WorkItem.cc
@@ -8,7 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 /// @author Tiago Quintino
 
 

--- a/src/gribjump/remote/WorkItem.h
+++ b/src/gribjump/remote/WorkItem.h
@@ -8,7 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 /// @author Tiago Quintino
 
 #pragma once

--- a/src/gribjump/remote/WorkQueue.cc
+++ b/src/gribjump/remote/WorkQueue.cc
@@ -54,8 +54,8 @@ void WorkQueue::workerLoop() {
         eckit::Log::status() << "Waiting for job" << std::endl;
         WorkItem item;
         if (!popNext(item)) {
-            LOG_DEBUG_LIB(LibGribJump)
-                << "Thread " << std::this_thread::get_id() << " stopping (queue closed)" << std::endl;
+            LOG_DEBUG_LIB(LibGribJump) << "Thread " << std::this_thread::get_id() << " stopping (queue closed)"
+                                       << std::endl;
             break;
         }
 
@@ -64,8 +64,8 @@ void WorkQueue::workerLoop() {
             item.run();
         }
         catch (const std::exception& e) {
-            LOG_DEBUG_LIB(LibGribJump)
-                << "Thread " << std::this_thread::get_id() << " exception: " << e.what() << std::endl;
+            LOG_DEBUG_LIB(LibGribJump) << "Thread " << std::this_thread::get_id() << " exception: " << e.what()
+                                       << std::endl;
             item.error(e.what());
         }
         catch (...) {

--- a/src/gribjump/remote/WorkQueue.cc
+++ b/src/gribjump/remote/WorkQueue.cc
@@ -8,7 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 
 #include "gribjump/remote/WorkQueue.h"
 

--- a/src/gribjump/remote/WorkQueue.cc
+++ b/src/gribjump/remote/WorkQueue.cc
@@ -11,11 +11,14 @@
 /// @author Christopher Bradley
 
 #include "gribjump/remote/WorkQueue.h"
+
+#include "eckit/exception/Exceptions.h"
 #include "eckit/log/Log.h"
 #include "eckit/log/Plural.h"
+
 #include "gribjump/Config.h"
 #include "gribjump/LibGribJump.h"
-
+#include "gribjump/Task.h"
 
 namespace gribjump {
 
@@ -25,51 +28,128 @@ WorkQueue& WorkQueue::instance() {
 }
 
 WorkQueue::~WorkQueue() {
-    queue_.close();
+    {
+        std::lock_guard<std::mutex> lock(mtx_);
+        closed_ = true;
+    }
+    cvPop_.notify_all();
+    cvPush_.notify_all();
 
     for (auto& w : workers_) {
         w.join();
     }
 }
 
-WorkQueue::WorkQueue() : queue_(ConfigOptions::instance().queueSize()) {
+WorkQueue::WorkQueue() : maxSize_(ConfigOptions::instance().queueSize()) {
     int nthreads = ConfigOptions::instance().numThreads();
-    eckit::Log::info() << "Starting " << eckit::Plural(nthreads, "thread") << std::endl;
+    eckit::Log::info() << "Starting " << eckit::Plural(nthreads, "thread")
+                       << " (round-robin work queue, capacity " << maxSize_ << ")" << std::endl;
     for (int i = 0; i < nthreads; ++i) {
-        workers_.emplace_back([this] {
-            LOG_DEBUG_LIB(LibGribJump) << "Thread " << std::this_thread::get_id() << " starting" << std::endl;
-            // GribJump gj = GribJump(); // one per thread
-
-            for (;;) {
-                eckit::Log::status() << "Waiting for job" << std::endl;
-                WorkItem item;
-                if (queue_.pop(item) == -1) {
-                    LOG_DEBUG_LIB(LibGribJump)
-                        << "Thread " << std::this_thread::get_id() << " stopping (queue closed)" << std::endl;
-                    break;
-                }
-                LOG_DEBUG_LIB(LibGribJump) << "Thread " << std::this_thread::get_id() << " new job" << std::endl;
-                try {
-                    item.run();
-                }
-                catch (const std::exception& e) {
-                    LOG_DEBUG_LIB(LibGribJump)
-                        << "Thread " << std::this_thread::get_id() << " exception: " << e.what() << std::endl;
-                    item.error(e.what());
-                }
-                catch (...) {
-                    LOG_DEBUG_LIB(LibGribJump)
-                        << "Thread " << std::this_thread::get_id() << " unknown exception" << std::endl;
-                    item.error("Unknown exception");
-                }
-            }
-        });
+        workers_.emplace_back([this] { workerLoop(); });
     }
 }
 
-void WorkQueue::push(Task* task) {
-    WorkItem item(task);
-    queue_.push(item);
+void WorkQueue::workerLoop() {
+    LOG_DEBUG_LIB(LibGribJump) << "Thread " << std::this_thread::get_id() << " starting" << std::endl;
+
+    for (;;) {
+        eckit::Log::status() << "Waiting for job" << std::endl;
+        WorkItem item;
+        if (!popNext(item)) {
+            LOG_DEBUG_LIB(LibGribJump)
+                << "Thread " << std::this_thread::get_id() << " stopping (queue closed)" << std::endl;
+            break;
+        }
+
+        LOG_DEBUG_LIB(LibGribJump) << "Thread " << std::this_thread::get_id() << " new job" << std::endl;
+        try {
+            item.run();
+        }
+        catch (const std::exception& e) {
+            LOG_DEBUG_LIB(LibGribJump)
+                << "Thread " << std::this_thread::get_id() << " exception: " << e.what() << std::endl;
+            item.error(e.what());
+        }
+        catch (...) {
+            LOG_DEBUG_LIB(LibGribJump) << "Thread " << std::this_thread::get_id() << " unknown exception" << std::endl;
+            item.error("Unknown exception");
+        }
+    }
+}
+
+bool WorkQueue::popNext(WorkItem& item) {
+    Task* task = nullptr;
+    {
+        std::unique_lock<std::mutex> lock(mtx_);
+        cvPop_.wait(lock, [&] { return closed_ || !rrOrder_.empty(); });
+
+        if (rrOrder_.empty()) {
+            // closed_ must be true here
+            return false;
+        }
+
+        // Round-robin: serve the group at the front, then rotate it to the back
+        // (if it still has tasks) or remove it (if drained).
+        TaskGroup* group = rrOrder_.front();
+        rrOrder_.pop_front();
+
+        auto it = groupQueues_.find(group);
+        ASSERT(it != groupQueues_.end());
+        ASSERT(!it->second.empty());
+
+        task = it->second.front();
+        it->second.pop_front();
+        --totalTasks_;
+
+        if (it->second.empty()) {
+            groupQueues_.erase(it);
+        }
+        else {
+            rrOrder_.push_back(group);
+        }
+    }
+
+    cvPush_.notify_all();  // wake any blocked producers; fair contention via notify_all
+    item = WorkItem(task);
+    return true;
+}
+
+void WorkQueue::push(TaskGroup* group, Task* task) {
+    ASSERT(group != nullptr);
+    ASSERT(task != nullptr);
+
+    bool wasEmpty = false;
+    {
+        std::unique_lock<std::mutex> lock(mtx_);
+
+        // Admission bypass: a brand new group (not currently in the rotation)
+        // is always allowed to enqueue its first task, so a saturating
+        // producer cannot starve newcomers out of the round-robin schedule.
+        auto it = groupQueues_.find(group);
+        if (it != groupQueues_.end()) {
+            cvPush_.wait(lock, [&] { return closed_ || totalTasks_ < maxSize_; });
+            if (closed_) {
+                throw eckit::SeriousBug("WorkQueue::push called after queue was closed");
+            }
+            it->second.push_back(task);
+        }
+        else {
+            if (closed_) {
+                throw eckit::SeriousBug("WorkQueue::push called after queue was closed");
+            }
+            groupQueues_.emplace(group, std::deque<Task*>{task});
+            rrOrder_.push_back(group);
+            wasEmpty = true;
+        }
+        ++totalTasks_;
+    }
+
+    if (wasEmpty) {
+        cvPop_.notify_all();  // multiple workers may be waiting; let them race
+    }
+    else {
+        cvPop_.notify_one();
+    }
 }
 
 }  // namespace gribjump

--- a/src/gribjump/remote/WorkQueue.cc
+++ b/src/gribjump/remote/WorkQueue.cc
@@ -32,18 +32,16 @@ WorkQueue::~WorkQueue() {
         std::lock_guard<std::mutex> lock(mtx_);
         closed_ = true;
     }
-    cvPop_.notify_all();
-    cvPush_.notify_all();
+    cv_.notify_all();
 
     for (auto& w : workers_) {
         w.join();
     }
 }
 
-WorkQueue::WorkQueue() : maxSize_(ConfigOptions::instance().queueSize()) {
+WorkQueue::WorkQueue() {
     int nthreads = ConfigOptions::instance().numThreads();
-    eckit::Log::info() << "Starting " << eckit::Plural(nthreads, "thread")
-                       << " (round-robin work queue, capacity " << maxSize_ << ")" << std::endl;
+    eckit::Log::info() << "Starting " << eckit::Plural(nthreads, "thread") << " (round-robin work queue)" << std::endl;
     for (int i = 0; i < nthreads; ++i) {
         workers_.emplace_back([this] { workerLoop(); });
     }
@@ -78,38 +76,33 @@ void WorkQueue::workerLoop() {
 }
 
 bool WorkQueue::popNext(WorkItem& item) {
-    Task* task = nullptr;
-    {
-        std::unique_lock<std::mutex> lock(mtx_);
-        cvPop_.wait(lock, [&] { return closed_ || !rrOrder_.empty(); });
+    std::unique_lock<std::mutex> lock(mtx_);
+    cv_.wait(lock, [&] { return closed_ || !rrOrder_.empty(); });
 
-        if (rrOrder_.empty()) {
-            // closed_ must be true here
-            return false;
-        }
-
-        // Round-robin: serve the group at the front, then rotate it to the back
-        // (if it still has tasks) or remove it (if drained).
-        TaskGroup* group = rrOrder_.front();
-        rrOrder_.pop_front();
-
-        auto it = groupQueues_.find(group);
-        ASSERT(it != groupQueues_.end());
-        ASSERT(!it->second.empty());
-
-        task = it->second.front();
-        it->second.pop_front();
-        --totalTasks_;
-
-        if (it->second.empty()) {
-            groupQueues_.erase(it);
-        }
-        else {
-            rrOrder_.push_back(group);
-        }
+    if (rrOrder_.empty()) {
+        // closed_ must be true here
+        return false;
     }
 
-    cvPush_.notify_all();  // wake any blocked producers; fair contention via notify_all
+    // Round-robin: serve the group at the front, then rotate it to the back
+    // (if it still has tasks) or remove it (if drained).
+    TaskGroup* group = rrOrder_.front();
+    rrOrder_.pop_front();
+
+    auto it = groupQueues_.find(group);
+    ASSERT(it != groupQueues_.end());
+    ASSERT(!it->second.empty());
+
+    Task* task = it->second.front();
+    it->second.pop_front();
+
+    if (it->second.empty()) {
+        groupQueues_.erase(it);
+    }
+    else {
+        rrOrder_.push_back(group);
+    }
+
     item = WorkItem(task);
     return true;
 }
@@ -118,38 +111,18 @@ void WorkQueue::push(TaskGroup* group, Task* task) {
     ASSERT(group != nullptr);
     ASSERT(task != nullptr);
 
-    bool wasEmpty = false;
     {
-        std::unique_lock<std::mutex> lock(mtx_);
+        std::lock_guard<std::mutex> lock(mtx_);
+        ASSERT(!closed_);
 
-        // Admission bypass: a brand new group (not currently in the rotation)
-        // is always allowed to enqueue its first task, so a saturating
-        // producer cannot starve newcomers out of the round-robin schedule.
-        auto it = groupQueues_.find(group);
-        if (it != groupQueues_.end()) {
-            cvPush_.wait(lock, [&] { return closed_ || totalTasks_ < maxSize_; });
-            if (closed_) {
-                throw eckit::SeriousBug("WorkQueue::push called after queue was closed");
-            }
-            it->second.push_back(task);
-        }
-        else {
-            if (closed_) {
-                throw eckit::SeriousBug("WorkQueue::push called after queue was closed");
-            }
-            groupQueues_.emplace(group, std::deque<Task*>{task});
+        auto [it, inserted] = groupQueues_.try_emplace(group);
+        if (inserted) {
             rrOrder_.push_back(group);
-            wasEmpty = true;
         }
-        ++totalTasks_;
+        it->second.push_back(task);
     }
 
-    if (wasEmpty) {
-        cvPop_.notify_all();  // multiple workers may be waiting; let them race
-    }
-    else {
-        cvPop_.notify_one();
-    }
+    cv_.notify_one();
 }
 
 }  // namespace gribjump

--- a/src/gribjump/remote/WorkQueue.h
+++ b/src/gribjump/remote/WorkQueue.h
@@ -12,18 +12,37 @@
 
 #pragma once
 
+#include <condition_variable>
+#include <deque>
+#include <list>
+#include <mutex>
 #include <thread>
-
-#include "eckit/container/Queue.h"
+#include <unordered_map>
+#include <vector>
 
 #include "gribjump/ExtractionData.h"
-#include "gribjump/Task.h"
 #include "gribjump/remote/WorkItem.h"
 
 namespace gribjump {
 
+class Task;
+class TaskGroup;
+
 //----------------------------------------------------------------------------------------------------------------------
 
+/// Round-robin, multi-queue work scheduler shared by all worker threads.
+///
+/// Each TaskGroup gets its own internal FIFO queue. Worker threads pop tasks
+/// by visiting the groups in round-robin order, so a single very large
+/// TaskGroup cannot block tasks belonging to other groups.
+///
+/// Notes on fairness:
+/// - Round-robin is per-task: a worker takes one task from group A, the next
+///   worker takes one from group B, etc.
+/// - A new TaskGroup is always admitted (its first task bypasses the global
+///   backpressure cap), so a saturating producer cannot prevent newcomers
+///   from entering the rotation.
+/// - Subsequent pushes by an already-admitted group respect the global cap.
 class WorkQueue {
 public:
 
@@ -36,7 +55,9 @@ public:
 
     ~WorkQueue();
 
-    void push(Task* task);
+    /// Enqueue a task belonging to the given task group.
+    /// May block if the queue is at capacity and the group is already admitted.
+    void push(TaskGroup* group, Task* task);
 
 protected:
 
@@ -44,7 +65,32 @@ protected:
 
 private:
 
-    eckit::Queue<WorkItem> queue_;
+    /// Worker loop: pops tasks in round-robin order across groups and runs them.
+    void workerLoop();
+
+    /// Pop one task from the next group in round-robin order.
+    /// Returns false if the queue has been closed and is empty.
+    bool popNext(WorkItem& item);
+
+private:
+
+    mutable std::mutex mtx_;
+    std::condition_variable cvPop_;   //< signalled when tasks become available or the queue is closed
+    std::condition_variable cvPush_;  //< signalled when slots free up or the queue is closed
+
+    bool closed_       = false;
+    size_t totalTasks_ = 0;
+    size_t maxSize_;
+
+    /// Per-group FIFO of pending tasks. A group is only present here while it
+    /// has at least one queued task; it is erased once drained and re-added on
+    /// the next push.
+    std::unordered_map<TaskGroup*, std::deque<Task*>> groupQueues_;
+
+    /// Round-robin order of groups with pending tasks. Each TaskGroup appears
+    /// at most once. The front is the next group to be served.
+    std::list<TaskGroup*> rrOrder_;
+
     std::vector<std::thread> workers_;
 };
 

--- a/src/gribjump/remote/WorkQueue.h
+++ b/src/gribjump/remote/WorkQueue.h
@@ -8,7 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 
 #pragma once
 

--- a/src/gribjump/remote/WorkQueue.h
+++ b/src/gribjump/remote/WorkQueue.h
@@ -32,17 +32,14 @@ class TaskGroup;
 
 /// Round-robin, multi-queue work scheduler shared by all worker threads.
 ///
-/// Each TaskGroup gets its own internal FIFO queue. Worker threads pop tasks
+/// Each TaskGroup has its own internal FIFO queue. Worker threads pop tasks
 /// by visiting the groups in round-robin order, so a single very large
 /// TaskGroup cannot block tasks belonging to other groups.
 ///
-/// Notes on fairness:
-/// - Round-robin is per-task: a worker takes one task from group A, the next
-///   worker takes one from group B, etc.
-/// - A new TaskGroup is always admitted (its first task bypasses the global
-///   backpressure cap), so a saturating producer cannot prevent newcomers
-///   from entering the rotation.
-/// - Subsequent pushes by an already-admitted group respect the global cap.
+/// The queue is unbounded: tasks are small handles whose payloads are already
+/// allocated by the producer before push() is called, so capping the number
+/// of queued tasks does not cap any meaningful resource. Producers never
+/// block on push.
 class WorkQueue {
 public:
 
@@ -55,8 +52,7 @@ public:
 
     ~WorkQueue();
 
-    /// Enqueue a task belonging to the given task group.
-    /// May block if the queue is at capacity and the group is already admitted.
+    /// Enqueue a task belonging to the given task group. Never blocks.
     void push(TaskGroup* group, Task* task);
 
 protected:
@@ -65,7 +61,6 @@ protected:
 
 private:
 
-    /// Worker loop: pops tasks in round-robin order across groups and runs them.
     void workerLoop();
 
     /// Pop one task from the next group in round-robin order.
@@ -75,12 +70,8 @@ private:
 private:
 
     mutable std::mutex mtx_;
-    std::condition_variable cvPop_;   //< signalled when tasks become available or the queue is closed
-    std::condition_variable cvPush_;  //< signalled when slots free up or the queue is closed
-
-    bool closed_       = false;
-    size_t totalTasks_ = 0;
-    size_t maxSize_;
+    std::condition_variable cv_;  //< signalled when tasks become available or the queue is closed
+    bool closed_ = false;
 
     /// Per-group FIFO of pending tasks. A group is only present here while it
     /// has at least one queued task; it is erased once drained and re-added on

--- a/src/gribjump/tools/EccodesExtract.cc
+++ b/src/gribjump/tools/EccodesExtract.cc
@@ -7,7 +7,7 @@
  * granted to it by virtue of its status as an intergovernmental organisation nor
  * does it submit to any jurisdiction.
  */
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 
 #include <memory>
 

--- a/src/gribjump/tools/EccodesExtract.h
+++ b/src/gribjump/tools/EccodesExtract.h
@@ -7,7 +7,7 @@
  * granted to it by virtue of its status as an intergovernmental organisation nor
  * does it submit to any jurisdiction.
  */
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 
 #pragma once
 

--- a/src/gribjump/tools/ToolUtils.cc
+++ b/src/gribjump/tools/ToolUtils.cc
@@ -7,7 +7,7 @@
  * granted to it by virtue of its status as an intergovernmental organisation nor
  * does it submit to any jurisdiction.
  */
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 
 #include <fstream>
 

--- a/src/gribjump/tools/ToolUtils.h
+++ b/src/gribjump/tools/ToolUtils.h
@@ -7,7 +7,7 @@
  * granted to it by virtue of its status as an intergovernmental organisation nor
  * does it submit to any jurisdiction.
  */
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 
 #pragma once
 

--- a/src/tools/gribjump-dump-info.cc
+++ b/src/tools/gribjump-dump-info.cc
@@ -7,7 +7,7 @@
  * granted to it by virtue of its status as an intergovernmental organisation nor
  * does it submit to any jurisdiction.
  */
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 
 #include "gribjump/GribJump.h"
 #include "gribjump/info/InfoCache.h"

--- a/src/tools/gribjump-extract.cc
+++ b/src/tools/gribjump-extract.cc
@@ -7,7 +7,7 @@
  * granted to it by virtue of its status as an intergovernmental organisation nor
  * does it submit to any jurisdiction.
  */
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 
 #include <fstream>
 

--- a/src/tools/gribjump-info.cc
+++ b/src/tools/gribjump-info.cc
@@ -7,7 +7,7 @@
  * granted to it by virtue of its status as an intergovernmental organisation nor
  * does it submit to any jurisdiction.
  */
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 
 #include "gribjump/GribJump.h"
 #include "gribjump/info/InfoCache.h"

--- a/src/tools/gribjump-scan-files.cc
+++ b/src/tools/gribjump-scan-files.cc
@@ -14,7 +14,7 @@
 #include "gribjump/GribJump.h"
 #include "gribjump/tools/GribJumpTool.h"
 
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 
 /// Tool to scan a set of files to built a GribJump info index. Assumes that the files are local.
 /// Output directory is specified in the configuration file.

--- a/src/tools/gribjump-scan.cc
+++ b/src/tools/gribjump-scan.cc
@@ -21,7 +21,7 @@
 #include "gribjump/tools/GribJumpTool.h"
 
 /// @author Tiago Quintino
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 
 /// Tool to execute the scanning of the FDB and building the GribJump info
 /// either locally or remotely on the GribJump server

--- a/src/tools/gribjump-validate.cc
+++ b/src/tools/gribjump-validate.cc
@@ -7,7 +7,7 @@
  * granted to it by virtue of its status as an intergovernmental organisation nor
  * does it submit to any jurisdiction.
  */
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 
 #include <fstream>
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -129,6 +129,15 @@ ecbuild_add_test(
     LIBS gribjump
 )
 
+ecbuild_add_test(
+    TARGET "gribjump_test_workqueue"
+    SOURCES "test_workqueue.cc"
+    INCLUDES "${ECKIT_INCLUDE_DIRS}"
+    ENVIRONMENT "GRIBJUMP_THREADS=1;${gribjump_env}"
+    NO_AS_NEEDED
+    LIBS gribjump
+)
+
 # c compiler test
 ecbuild_add_test(
     TARGET "gribjump_test_c_compile"

--- a/tests/test_c_compile.c
+++ b/tests/test_c_compile.c
@@ -10,7 +10,7 @@
 
 /// @file   test_c_api.c
 /// @date   Dec 2024
-/// @author Christopher Bradley
+/// @author Caragh Bradley
 
 #include <stdio.h>
 #include "gribjump/gribjump_c.h"

--- a/tests/test_workqueue.cc
+++ b/tests/test_workqueue.cc
@@ -21,6 +21,7 @@
 #include <chrono>
 #include <condition_variable>
 #include <cstddef>
+#include <functional>
 #include <mutex>
 #include <string>
 #include <utility>

--- a/tests/test_workqueue.cc
+++ b/tests/test_workqueue.cc
@@ -1,0 +1,277 @@
+/*
+ * (C) Copyright 2024- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation
+ * nor does it submit to any jurisdiction.
+ */
+
+/// Unit tests for the round-robin WorkQueue scheduler.
+///
+/// These tests verify that the WorkQueue dispatches tasks fairly across
+/// TaskGroups in round-robin order, and in particular that a large
+/// TaskGroup cannot block a smaller one from making progress.
+///
+/// The tests rely on running with a single worker thread so that the
+/// dispatch order is deterministic; this is enforced via the
+/// GRIBJUMP_THREADS=1 environment variable set in the test's CMakeLists.
+
+#include <chrono>
+#include <condition_variable>
+#include <cstddef>
+#include <mutex>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "eckit/testing/Test.h"
+
+#include "gribjump/Task.h"
+
+using namespace eckit::testing;
+
+namespace gribjump {
+namespace test {
+
+//-----------------------------------------------------------------------------
+// Test helpers
+
+/// Shared log of (group_label, sequence) pairs in order of dispatch.
+struct DispatchLog {
+    std::mutex m;
+    std::vector<std::pair<std::string, size_t>> entries;
+
+    void record(const std::string& label, size_t seq) {
+        std::lock_guard<std::mutex> lock(m);
+        entries.emplace_back(label, seq);
+    }
+
+    size_t size() {
+        std::lock_guard<std::mutex> lock(m);
+        return entries.size();
+    }
+};
+
+/// Minimal Task that records its identity when executed. Used to observe
+/// the order in which the scheduler dispatches tasks.
+class DummyTask : public Task {
+public:
+
+    DummyTask(TaskGroup& g, size_t id, std::string label, size_t seq, DispatchLog& log) :
+        Task(g, id), label_(std::move(label)), seq_(seq), log_(log) {}
+
+    void executeImpl() override { log_.record(label_, seq_); }
+
+    void info() const override {}
+
+private:
+
+    std::string label_;
+    size_t seq_;
+    DispatchLog& log_;
+};
+
+/// Task that signals when it starts executing and then blocks until released.
+/// Used to hold the (single) worker thread while we enqueue test tasks, so
+/// that the scheduler's dispatch order is observable rather than racy with
+/// the producer.
+class BlockerTask : public Task {
+public:
+
+    BlockerTask(TaskGroup& g, size_t id, std::mutex& m, std::condition_variable& cv, bool& started, bool& release) :
+        Task(g, id), m_(m), cv_(cv), started_(started), release_(release) {}
+
+    void executeImpl() override {
+        {
+            std::lock_guard<std::mutex> lock(m_);
+            started_ = true;
+        }
+        cv_.notify_all();
+
+        std::unique_lock<std::mutex> lock(m_);
+        cv_.wait(lock, [&] { return release_; });
+    }
+
+    void info() const override {}
+
+private:
+
+    std::mutex& m_;
+    std::condition_variable& cv_;
+    bool& started_;
+    bool& release_;
+};
+
+/// RAII helper: enqueues a BlockerTask on its own TaskGroup, waits for it to
+/// start executing (occupying the worker), and releases it on destruction
+/// (or via release()). While the blocker is held, the caller can freely
+/// enqueue tasks into other TaskGroups without any of them being dispatched.
+class WorkerGate {
+public:
+
+    WorkerGate() {
+        group_.enqueueTask<BlockerTask>(std::ref(m_), std::ref(cv_), std::ref(started_), std::ref(release_));
+        std::unique_lock<std::mutex> lock(m_);
+        cv_.wait(lock, [&] { return started_; });
+    }
+
+    ~WorkerGate() {
+        release();
+        group_.waitForTasks();
+    }
+
+    void release() {
+        {
+            std::lock_guard<std::mutex> lock(m_);
+            if (release_)
+                return;
+            release_ = true;
+        }
+        cv_.notify_all();
+    }
+
+private:
+
+    TaskGroup group_;
+    std::mutex m_;
+    std::condition_variable cv_;
+    bool started_ = false;
+    bool release_ = false;
+};
+
+//-----------------------------------------------------------------------------
+// Tests
+
+CASE("round_robin_large_does_not_block_small") {
+    // Push a large group (A, 6 tasks) followed entirely by a small group
+    // (B, 3 tasks). Under the old FIFO queue, B would have to wait for the
+    // whole of A. With round-robin, the worker should interleave them.
+
+    DispatchLog log;
+    TaskGroup groupA;
+    TaskGroup groupB;
+
+    {
+        WorkerGate gate;  // worker is now stuck inside the blocker
+
+        for (size_t i = 0; i < 6; ++i) {
+            groupA.enqueueTask<DummyTask>(std::string("A"), i, std::ref(log));
+        }
+        for (size_t i = 0; i < 3; ++i) {
+            groupB.enqueueTask<DummyTask>(std::string("B"), i, std::ref(log));
+        }
+        // gate releases here; the worker then drains the queue in RR order
+    }
+
+    groupA.waitForTasks();
+    groupB.waitForTasks();
+
+    const std::vector<std::pair<std::string, size_t>> expected = {
+        {"A", 0}, {"B", 0}, {"A", 1}, {"B", 1}, {"A", 2}, {"B", 2},
+        {"A", 3}, {"A", 4}, {"A", 5},
+    };
+
+    EXPECT_EQUAL(log.entries.size(), expected.size());
+    for (size_t i = 0; i < expected.size(); ++i) {
+        EXPECT_EQUAL(log.entries[i].first, expected[i].first);
+        EXPECT_EQUAL(log.entries[i].second, expected[i].second);
+    }
+
+    // Headline property: the small group must finish before the large group.
+    auto lastIndexOf = [&](const std::string& label) {
+        size_t idx = 0;
+        for (size_t i = 0; i < log.entries.size(); ++i) {
+            if (log.entries[i].first == label)
+                idx = i;
+        }
+        return idx;
+    };
+    EXPECT(lastIndexOf("B") < lastIndexOf("A"));
+}
+
+CASE("round_robin_three_equal_groups") {
+    // Three groups of equal size pushed back-to-back. With round-robin we
+    // expect a perfect A,B,C,A,B,C,... interleaving regardless of push order.
+
+    DispatchLog log;
+    TaskGroup groupA;
+    TaskGroup groupB;
+    TaskGroup groupC;
+
+    const size_t N = 4;
+
+    {
+        WorkerGate gate;
+
+        for (size_t i = 0; i < N; ++i)
+            groupA.enqueueTask<DummyTask>(std::string("A"), i, std::ref(log));
+        for (size_t i = 0; i < N; ++i)
+            groupB.enqueueTask<DummyTask>(std::string("B"), i, std::ref(log));
+        for (size_t i = 0; i < N; ++i)
+            groupC.enqueueTask<DummyTask>(std::string("C"), i, std::ref(log));
+    }
+
+    groupA.waitForTasks();
+    groupB.waitForTasks();
+    groupC.waitForTasks();
+
+    EXPECT_EQUAL(log.entries.size(), 3 * N);
+
+    std::vector<std::pair<std::string, size_t>> expected;
+    expected.reserve(3 * N);
+    for (size_t i = 0; i < N; ++i) {
+        expected.emplace_back("A", i);
+        expected.emplace_back("B", i);
+        expected.emplace_back("C", i);
+    }
+
+    for (size_t i = 0; i < expected.size(); ++i) {
+        EXPECT_EQUAL(log.entries[i].first, expected[i].first);
+        EXPECT_EQUAL(log.entries[i].second, expected[i].second);
+    }
+}
+
+CASE("round_robin_unequal_groups_drains_in_order") {
+    // Groups of sizes 1, 2, 5 pushed in that order. Expected dispatch:
+    //   A0, B0, C0, B1, C1, C2, C3, C4
+    // i.e. each group rotates until it is exhausted, then drops out.
+
+    DispatchLog log;
+    TaskGroup groupA;
+    TaskGroup groupB;
+    TaskGroup groupC;
+
+    {
+        WorkerGate gate;
+
+        groupA.enqueueTask<DummyTask>(std::string("A"), 0, std::ref(log));
+        for (size_t i = 0; i < 2; ++i)
+            groupB.enqueueTask<DummyTask>(std::string("B"), i, std::ref(log));
+        for (size_t i = 0; i < 5; ++i)
+            groupC.enqueueTask<DummyTask>(std::string("C"), i, std::ref(log));
+    }
+
+    groupA.waitForTasks();
+    groupB.waitForTasks();
+    groupC.waitForTasks();
+
+    const std::vector<std::pair<std::string, size_t>> expected = {
+        {"A", 0}, {"B", 0}, {"C", 0}, {"B", 1}, {"C", 1}, {"C", 2}, {"C", 3}, {"C", 4},
+    };
+
+    EXPECT_EQUAL(log.entries.size(), expected.size());
+    for (size_t i = 0; i < expected.size(); ++i) {
+        EXPECT_EQUAL(log.entries[i].first, expected[i].first);
+        EXPECT_EQUAL(log.entries[i].second, expected[i].second);
+    }
+}
+
+}  // namespace test
+}  // namespace gribjump
+
+
+int main(int argc, char** argv) {
+    return run_tests(argc, argv);
+}

--- a/tests/test_workqueue.cc
+++ b/tests/test_workqueue.cc
@@ -24,6 +24,7 @@
 #include <functional>
 #include <mutex>
 #include <string>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -259,6 +260,53 @@ CASE("round_robin_unequal_groups_drains_in_order") {
 
     const std::vector<std::pair<std::string, size_t>> expected = {
         {"A", 0}, {"B", 0}, {"C", 0}, {"B", 1}, {"C", 1}, {"C", 2}, {"C", 3}, {"C", 4},
+    };
+
+    EXPECT_EQUAL(log.entries.size(), expected.size());
+    for (size_t i = 0; i < expected.size(); ++i) {
+        EXPECT_EQUAL(log.entries[i].first, expected[i].first);
+        EXPECT_EQUAL(log.entries[i].second, expected[i].second);
+    }
+}
+
+CASE("group_drains_and_is_readmitted") {
+    // Verify that a group whose queue is fully drained by the worker can
+    // re-enter the rotation when the producer pushes more tasks afterwards.
+    // The re-admitted group should join at the back of the rotation.
+
+    DispatchLog log;
+    TaskGroup groupA;
+    TaskGroup groupB;
+
+    // Phase 1: enqueue and fully drain A on its own.
+    {
+        WorkerGate gate;
+        groupA.enqueueTask<DummyTask>(std::string("A"), 0, std::ref(log));
+        groupA.enqueueTask<DummyTask>(std::string("A"), 1, std::ref(log));
+    }
+    // Wait for A's two tasks to actually finish executing, so A is removed
+    // from the WorkQueue's rotation before phase 2.
+    while (log.size() < 2) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+
+    // Phase 2: with A drained, push more A tasks together with B tasks.
+    // B is the first to push, so B joins the rotation first; A's re-admission
+    // goes behind B. Expected: B0, A2, B1, A3.
+    {
+        WorkerGate gate;
+        groupB.enqueueTask<DummyTask>(std::string("B"), 0, std::ref(log));
+        groupA.enqueueTask<DummyTask>(std::string("A"), 2, std::ref(log));
+        groupB.enqueueTask<DummyTask>(std::string("B"), 1, std::ref(log));
+        groupA.enqueueTask<DummyTask>(std::string("A"), 3, std::ref(log));
+    }
+
+    groupA.waitForTasks();
+    groupB.waitForTasks();
+
+    const std::vector<std::pair<std::string, size_t>> expected = {
+        {"A", 0}, {"A", 1},                      // phase 1
+        {"B", 0}, {"A", 2}, {"B", 1}, {"A", 3},  // phase 2: A is re-admitted behind B
     };
 
     EXPECT_EQUAL(log.entries.size(), expected.size());

--- a/tests/test_workqueue.cc
+++ b/tests/test_workqueue.cc
@@ -169,8 +169,7 @@ CASE("round_robin_large_does_not_block_small") {
     groupB.waitForTasks();
 
     const std::vector<std::pair<std::string, size_t>> expected = {
-        {"A", 0}, {"B", 0}, {"A", 1}, {"B", 1}, {"A", 2}, {"B", 2},
-        {"A", 3}, {"A", 4}, {"A", 5},
+        {"A", 0}, {"B", 0}, {"A", 1}, {"B", 1}, {"A", 2}, {"B", 2}, {"A", 3}, {"A", 4}, {"A", 5},
     };
 
     EXPECT_EQUAL(log.entries.size(), expected.size());


### PR DESCRIPTION
### Description

Replace fifo queue with round robin scheudling.

Also, the fifo queue had a max size (as that was required by eckit::Queue), but it did not in anyway control the resource usage (producers are already holding all their state in memory before reaching the queue). So this has been uncapped.

(renamed #96 for jira)

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
