### PR TITLE
Relax version check and ignore build number in Python wheels

### DIFF
--- a/python/pygribjump/src/pygribjump/pygribjump.py
+++ b/python/pygribjump/src/pygribjump/pygribjump.py
@@ -71,7 +71,8 @@ class PatchedLib:
         # Check versions
         versionstr = ffi.string(self.gribjump_version()).decode("utf-8")
 
-        if versionstr != __version__:
+        # Compare (major, minor, patch) only, ignoring any build-number suffix on the wheel
+        if version.parse(versionstr).release[:3] != version.parse(__version__).release[:3]:
             warnings.warn(
                 f"GribJump library version {versionstr} does not match pygribjump version {__version__}")
 


### PR DESCRIPTION
### Description

Ignore wheel build-number suffixes when comparing pygribjump and libgribjump versions. This avoids false-positive warnings for wheel builds (e.g. `0.10.4` vs `0.10.4.19`) while still validating major/minor/patch compatibility.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
