### PR TITLE
[python] dynamic gribjumplib constraint

### DIFF
--- a/.github/workflows/build-wheel-wrapper.yml
+++ b/.github/workflows/build-wheel-wrapper.yml
@@ -29,6 +29,7 @@ on:
         default: false
 
 jobs:
+  # NOTE for now, don't remove this file -- we sadly rely on it to determine the location of the `wheel_directory`
   python-wrapper-wheel:
     name: Python Wrapper Wheel
     uses: ecmwf/reusable-workflows/.github/workflows/python-wrapper-wheel.yml@main

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -9,11 +9,3 @@ jobs:
   deploy:
     uses: ecmwf/reusable-workflows/.github/workflows/create-package.yml@v2
     secrets: inherit
-  wheel-wrapper:
-    uses: ./.github/workflows/build-wheel-wrapper.yml
-    secrets: inherit
-  wheel-python:
-    uses: ecmwf/reusable-workflows/.github/workflows/cd-pypi.yml@v2
-    secrets: inherit
-    needs:
-      - wheel-wrapper

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,26 +16,14 @@ name = "pygribjump"
 description = "Python interface to GribJump"
 readme = "README.md"
 requires-python = ">=3.10"
-dynamic = ["version"]
+# NOTE do *not* include static dependencies here -- we need dynamicity for the gribjumplib constraint
+dynamic = ["version", "dependencies", "optional-dependencies"]
 authors = [
     { name = "ECMWF", email = "software.support@ecmwf.int" }
 ]
 license = "Apache-2.0"
 license-files = ["LICENSE"]
 urls = { "Home" = "https://github.com/ecmwf/gribjump" }
-dependencies = [
-    "cffi>=2.0,<3.0",
-    "numpy>=1.26",
-    "findlibs>=0.1.1",
-    "packaging>=20.0",
-]
-
-[project.optional-dependencies]
-dev = [
-    "pytest>=8.3",
-    "pyyaml",
-    "pyfdb",
-]
 
 [tool.setuptools.dynamic]
 version = { file = ["VERSION"] }

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,25 @@
+import os
+from setuptools import setup
+from pathlib import Path
+
+setup(
+    install_requires=[
+        "cffi>=2.0,<3.0",
+        "numpy>=1.26",
+        "findlibs>=0.1.1",
+        "packaging>=20.0",
+    ],
+    extras_require={
+        "dev": [
+            "pytest>=8.3",
+            "pyyaml",
+            "pyfdb",
+        ],
+        "binary": [
+            # NOTE for locally built wheel, this is not going to provide a
+            # satisfiable constraint -- but we dont expect local wheels to
+            # be installed with this extra
+            "gribjumplib==" + Path("VERSION").read_text().strip(),
+        ],
+    }
+)


### PR DESCRIPTION
adds setup.py to support gribjumplib pin in the python pygribjumplib wheel. I don't think its possible to do without setup.py, and the setup.py has to reside where pyproject.toml is.

the dependency is optional, to not break the existing usecases

additionally I remove the invocation of a disabled action from cd.yml
